### PR TITLE
MCP: 正規URLを ruletrade.jp/mcp に統一し、llms.txt / OpenAPI / 英語ドキュメントを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,9 @@ Thumbs.db
 !mcp/vercel.json
 mcp/node_modules/
 mcp/.wrangler/
+
+# レジストリ登録用の JSON はコミット対象。秘密鍵は絶対に入れない
+!mcp/registry/server.github.json
+!mcp/registry/server.dns.json
+*.pem
+mcp/registry/server.json

--- a/mcp/HANDOFF.md
+++ b/mcp/HANDOFF.md
@@ -19,11 +19,11 @@
 | 項目 | 状態 |
 |---|---|
 | コード | `mcp/` 配下に完成。依存パッケージゼロ(Node 20+ の標準機能のみ) |
-| テスト | `cd mcp && npm test` → 16本すべて合格(実際の docs/*.json をフィクスチャに使用) |
+| テスト | `cd mcp && npm test` → 18本すべて合格(実際の docs/*.json をフィクスチャに使用) |
 | 本番データでの動作 | ローカル dev サーバーから GitHub raw の JSON を読んで4本とも正常応答を確認済み |
 | CI | `.github/workflows/mcp-test.yml` を追加(mcp/ 変更時に自動テスト) |
-| デプロイ | **未実施**(本人作業) |
-| main マージ | **未実施** |
+| デプロイ | **公開済み**(2026-09-04 Cloudflare Workers)。**正規URL = `https://ruletrade.jp/mcp`** |
+| main マージ | 済(PR #352 ほか) |
 
 ## 3. ファイル構成
 
@@ -33,13 +33,14 @@ mcp/
 │   ├── server.js      MCP Streamable HTTP(JSON-RPC・ステートレス)の実装、ルーティング、呼び出しログ
 │   ├── tools.js       ツール4本の定義(tools/list 用スキーマ)と実装
 │   ├── data.js        GitHub raw から JSON を取得(60秒キャッシュ)。DATA_BASE で差し替え可
-│   └── legal.js       免責文 DISCLAIMER・推奨語リスト NG_WORDS・伏せ字化 scrub()
+│   ├── legal.js       免責文 DISCLAIMER・推奨語リスト NG_WORDS・伏せ字化 scrub()
+│   └── docs.js        GET /llms.txt と GET /openapi.json(エージェント向けの発見用・英語主)
 ├── worker.js          Cloudflare Workers エントリ
 ├── api/[[...path]].js Vercel Functions エントリ(全パスを rewrite で集約)
 ├── vercel.json        Vercel 用 rewrite
 ├── wrangler.toml      Cloudflare 用(observability=有効。Analytics Engine はコメントアウト)
 ├── dev.js             ローカル確認用 http サーバー(node dev.js → :8787)
-├── test/server.test.js 16テスト
+├── test/server.test.js 18テスト
 ├── package.json
 ├── README.md          デプロイ手順・接続方法・環境変数
 └── HANDOFF.md         このファイル
@@ -57,7 +58,7 @@ mcp/
 | `get_anomaly_summary` | `docs/anomaly_results.json`, `docs/gauge.json`, `docs/crash.json` | `name`, `detail` | ジンクス50本の検証結果 + 『暴落は、減衰する』5前兆 + 着火メーター7フラグ |
 | `list_tools_guide` | なし(静的) | なし | 更新時刻・遅延・制限・免責・ロードマップ |
 
-エンドポイント: `POST /mcp`(MCP本体)、`GET /health`(5JSONの疎通)、`GET /`(概要)。`GET /mcp` は仕様どおり 405。
+エンドポイント: `POST /mcp`(MCP本体)、`GET /health`(5JSONの疎通)、`GET /llms.txt`、`GET /openapi.json`、`GET /`(概要)。`GET /mcp` は仕様どおり 405。
 
 ### 4-1. ジンクス検証データ(2026-09-04 追加)
 
@@ -70,6 +71,23 @@ mcp/
 - `name` 引数で名前/カテゴリの部分一致絞り込み。引数なしの一覧は判定のみの軽い形(全件+統計値だと約38K文字になるため)。
 - 検証不能・姉妹書送りの4本(決算またぎ / 優待の新設 / オリンピック / サザエさん効果)は `metrics` が空。
   落とさずに `verified: false` + `note`(理由)を付けて返す。
+
+### 4-2. 正規URLと配信経路(2026-09-05)
+
+```
+利用者 → https://ruletrade.jp/mcp  (Vercel 静的サイト・site/vercel.json の rewrite)
+                 ↓ プロキシ
+         https://ruletrade-mcp.oo12takemaru.workers.dev/mcp  (Cloudflare Workers 実体)
+```
+
+- **案内する URL は常に `https://ruletrade.jp/mcp`。`*.workers.dev` は案内しない**(テストで機械検査している)。
+  Worker を引っ越しても `site/vercel.json` の2行を直すだけで、レジストリ登録も利用者側も変わらない。
+- **DNS は変更していない**(2026-08-31 の DNS 移管失敗を繰り返さないため)。Cloudflare のカスタムドメインも使わない。
+- Vercel の rewrite 経由だと Worker から見た `url.origin` は workers.dev のままなので、
+  **URL をレスポンスに書くときは `src/tools.js` の `CANONICAL_ORIGIN` / `CANONICAL_ENDPOINT` / `HOME_URL` を使う**。
+  リクエストのホストから組み立ててはいけない。
+- `/mcp/health`・`/mcp/llms.txt`・`/mcp/openapi.json` は rewrite の2本目(`/mcp/(.*)` → Worker の `/$1`)で届く。
+- 呼び出しログは Worker 側にそのまま残る(プロキシしてもクライアント情報は失われない)。
 
 ## 5. 法務線の実装
 
@@ -101,7 +119,7 @@ mcp/
 ```bash
 git fetch origin claude/rule-trade-mcp-free-launch-136is2
 git checkout claude/rule-trade-mcp-free-launch-136is2
-cd mcp && npm test            # 16 pass を確認
+cd mcp && npm test            # 18 pass を確認
 node dev.js                   # 別ターミナルで
 curl -s localhost:8787/health
 curl -s -X POST localhost:8787/mcp -H 'content-type: application/json' \
@@ -114,11 +132,13 @@ Claude Code に渡す一言:
 ## 9. 公開までの残タスク(順番どおり)
 
 - [x] ジンクス検証JSONを特定して `get_anomaly_summary` を正式対応(2026-09-04・`docs/anomaly_results.json` として同梱)
-- [ ] **main へマージ(PR)** ← デプロイより先。raw main を読むため
-- [ ] Cloudflare にデプロイ(Root directory = `mcp`)→ `/health` が `"ok": true`
+- [x] main へマージ(PR #352)
+- [x] Cloudflare にデプロイ → `/health` が `"ok": true`(2026-09-04)
 - [ ] Claude Code から接続して4本の出力文言を目視: `claude mcp add --transport http ruletrade https://<host>/mcp`
-- [ ] claude.ai のカスタムコネクタでも接続確認(設定 → コネクタ → URL に `/mcp`)
-- [ ] 人向けサイトに MCP の案内を1行追加(URL と「投資助言ではない」旨)
+- [x] Claude Code から接続確認(2026-09-05・`https://ruletrade.jp/mcp` で ✔ Connected)
+- [ ] claude.ai のカスタムコネクタでも接続確認(設定 → コネクタ → URL に `https://ruletrade.jp/mcp`)= **本人作業**
+- [x] 人向けサイトに MCP の案内(`system.html`・`scanner.html`・`site/llms.txt`)
+- [ ] MCP レジストリ登録 = **本人作業**(登録内容の案は `mcp/registry/` にある)
 - [ ] 1週間後に呼び出しログを集計(ツール別回数・クライアント別)→ 有料化判断の材料
 
 ## 10. 触らないもの

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,8 +1,71 @@
-# ルールトレード MCP(無料版)
+# Rule Trade MCP — free tier / ルールトレード MCP(無料版)
+
+**Endpoint: `https://ruletrade.jp/mcp`**
+(`llms.txt`: `https://ruletrade.jp/mcp/llms.txt` · OpenAPI: `https://ruletrade.jp/mcp/openapi.json` · health: `https://ruletrade.jp/mcp/health`)
+
+---
+
+## English
+
+A **verification layer** for Japanese equities, exposed over MCP.
+
+Most Japanese-equity MCP servers cover the *primary data* layer — filings, prices, order execution.
+This one covers what is missing: **what actually happened when published, mechanical rules were applied.**
+It holds no engine of its own; it reads JSON that an existing pipeline publishes daily and reshapes it.
+Zero dependencies, no API key, no registration.
+
+### What you can get
+
+| Tool | Returns |
+|---|---|
+| `get_daily_signals` | Stocks that matched a published mean-reversion rule (25-day moving-average deviation ≤ -15%), plus near-miss watch candidates. Delayed one trading day, top 3 by deviation. |
+| `get_market_regime` | Machine-classified market regime (BULLISH / NEUTRAL / BEARISH / PANIC), circuit-breaker state, VIX, Nikkei 225, daily history. No stock names. |
+| `get_anomaly_summary` | **50 Japanese market anomalies tested over 61 years** — verdict, win rate, mean return, sample size, p-value, control group. Filter by `name`. Plus five crash-precursor gauges and a 7-flag ignition meter verified over 26 years. |
+| `list_tools_guide` | Update times (JST), delays, free-tier limits, disclaimer, roadmap. Call this first. |
+
+### What you cannot get — by design
+
+- Raw price series, OHLCV, or financial-statement values
+- Position sizing, entry/exit prices, stop-loss or take-profit levels
+- The production thresholds used by the operator's own system
+- Any recommendation, rating, or buy/sell signal
+
+Every response carries a `disclaimer` key. **Do not strip it when relaying results to a user.**
+Output describes whether mechanical rules matched. It is not investment advice, not a solicitation,
+and promises no future return.
+
+### How to connect
+
+```bash
+# Claude Code
+claude mcp add --transport http ruletrade https://ruletrade.jp/mcp
+```
+
+- **claude.ai**: Settings → Connectors → Add custom connector → `https://ruletrade.jp/mcp`
+- **Any MCP client**: POST JSON-RPC 2.0 to `https://ruletrade.jp/mcp` (Streamable HTTP, stateless)
+
+### Where the research comes from
+
+The rules and verification data are published as books by the operator (Japanese, Kindle):
+*Silent Investor BNF*, *Crashes Decay*, and *All 50 Japanese Market Anomalies Tested Over 61 Years*.
+The anomaly dataset is a fixed snapshot taken at that book's publication (2026-08) and is not updated daily.
+
+### Good to know
+
+- Data updates on Japan Exchange trading days. Exact times are in `list_tools_guide`.
+- Rate limits are not enforced today. Please be reasonable.
+- Statistical values are rounded; p-values use 3 significant figures so very small values stay readable.
+
+---
+
+## 日本語
 
 kaburadar.jp / ruletrade.jp が毎日公開している検証済みJSON(`docs/*.json`)を、
 AIエージェント(Claude / Cursor / ChatGPT 等)から MCP で読めるようにする **変換層** です。
 エンジンは持たず、GitHub raw の JSON を読んで整形するだけ。依存パッケージゼロ。
+
+**正規URL は `https://ruletrade.jp/mcp`**。実体は Cloudflare Workers だが、
+ruletrade.jp(Vercel)の `vercel.json` で rewrite しているため、配信先が変わっても利用者側の URL は変わらない。
 
 | ツール | 読むJSON | 内容 |
 |---|---|---|
@@ -31,6 +94,8 @@ JSON 非対応の `NaN` を `null` に置換したコピー。更新するとき
 |---|---|
 | `POST /mcp` | MCP Streamable HTTP(JSON-RPC・ステートレス) |
 | `GET /health` | 5つのJSONが読めるか確認 |
+| `GET /llms.txt` | エージェント向けの説明(英語主・日本語従) |
+| `GET /openapi.json` | OpenAPI 3.1。JSON-RPC を1エンドポイントとして記述 |
 | `GET /` | 概要 |
 
 ## デプロイ(どちらか一方でOK・スマホのブラウザから完結)
@@ -39,7 +104,9 @@ JSON 非対応の `NaN` を `null` に置換したコピー。更新するとき
 1. Cloudflare ダッシュボード → **Workers & Pages** → **Create** → **Import a repository**
 2. リポジトリ `stock-trading-` を選ぶ → **Root directory** に `mcp` を入れる
 3. Build command は空、Deploy command は `npx wrangler deploy`(既定のまま)
-4. Deploy → `https://ruletrade-mcp.<account>.workers.dev/mcp` がエンドポイント
+4. Deploy → Worker の実体は `https://ruletrade-mcp.<account>.workers.dev/mcp`。
+   **利用者に案内するのは正規URL `https://ruletrade.jp/mcp`**(ruletrade.jp の `site/vercel.json` が rewrite する)。
+   Worker の URL が変わったときは `site/vercel.json` の2行と `src/tools.js` の `CANONICAL_*` を直す
 5. ログ: Worker → **Logs**(`wrangler.toml` の observability で有効化済み)。`event:"tool_call"` で絞ると呼び出し数が見える
 
 ### B. Vercel
@@ -49,11 +116,12 @@ JSON 非対応の `NaN` を `null` に置換したコピー。更新するとき
 4. ログ: Project → **Logs**(Hobby は保持1時間なので、集計したい場合は下の `LOG_WEBHOOK` を使う)
 
 ### 動作確認(デプロイ後にブラウザで開くだけ)
-- `https://<host>/health` → `"ok": true` なら完了
+- `https://ruletrade.jp/mcp/health` → `"ok": true` なら完了
+- Worker 直の `https://ruletrade-mcp.<account>.workers.dev/health` でも同じものが見える(切り分け用)
 
-### 接続
-- **Claude(claude.ai)**: 設定 → コネクタ → カスタムコネクタを追加 → URL に `https://<host>/mcp`
-- **Claude Code**: `claude mcp add --transport http ruletrade https://<host>/mcp`
+### 接続(正規URLを使う。`*.workers.dev` は案内しない)
+- **Claude(claude.ai)**: 設定 → コネクタ → カスタムコネクタを追加 → URL に `https://ruletrade.jp/mcp`
+- **Claude Code**: `claude mcp add --transport http ruletrade https://ruletrade.jp/mcp`
 - 最初に `list_tools_guide` を呼ぶよう `initialize` の instructions で案内している
 
 ## 環境変数(すべて任意)
@@ -72,7 +140,7 @@ JSON 非対応の `NaN` を `null` に置換したコピー。更新するとき
 
 ```bash
 cd mcp
-npm test        # 実際の docs/*.json をフィクスチャに16テスト(推奨語ゼロ検査を含む)
+npm test        # 実際の docs/*.json をフィクスチャに18テスト(推奨語ゼロ検査を含む)
 node dev.js     # http://localhost:8787/mcp
 curl -s localhost:8787/health
 curl -s -X POST localhost:8787/mcp -H 'content-type: application/json' \

--- a/mcp/registry/README.md
+++ b/mcp/registry/README.md
@@ -1,0 +1,144 @@
+# レジストリ登録の要件と登録内容の案
+
+作成: 2026-09-05（起動文 `起動文_実務_MCP公開後仕上げ_2026-09-05.md` Step 5）
+状態: **未登録。実際の登録操作は本人が行う。**
+
+---
+
+## 1. 調べた結果（2026-09-05 時点）
+
+### MCP 公式レジストリ（registry.modelcontextprotocol.io）
+
+現在 **preview 版**（破壊的変更やデータリセットがあり得ると明記されている）。
+
+| 項目 | 結果 |
+|---|---|
+| リモートHTTPサーバーの登録 | **可能**。`remotes` 配列に `{"type":"streamable-http","url":"..."}` を書く。「URL で公開アクセス可能であること」が必須条件で、うちは満たしている |
+| npm 等へのパッケージ公開 | **不要**。パッケージ所有権の検証は `packages` を書いた場合の話。リモートのみの構成には該当しない |
+| 必要なファイル | `server.json` 1枚のみ |
+| 登録ツール | `mcp-publisher` CLI |
+| 審査 | 人手の審査は無し。名前空間の認証が通れば登録される |
+| OSSライセンスの公開義務 | **無し**（リポジトリは既に公開だが、要件ではない） |
+| ライセンス表記 | 任意 |
+
+**名前空間の認証は2択で、どちらを選ぶかで名前が決まる。**
+
+| 認証方式 | 名前の形 | うちの場合 | DNS変更 |
+|---|---|---|---|
+| GitHub | `io.github.<username>/*` | `io.github.oo12takemaru-create/ruletrade` | **不要** |
+| ドメイン | `<逆引きドメイン>/*` | `jp.ruletrade/mcp` | **必要**（`ruletrade.jp` の**apex**に TXT レコード） |
+
+- **`remotes` の URL は名前空間と一致しなくてよい。** GitHub 認証を選んでも、公開URLは `https://ruletrade.jp/mcp` のままで登録できる。
+- DNS 認証の TXT レコードは **apex（`ruletrade.jp` 直下）に置く必要がある**。`_mcp-auth.ruletrade.jp` のようなセレクタ配下では認証が通らないと明記されている。鍵をローテートしたら古いレコードの削除も必要。
+
+### Smithery（smithery.ai）
+
+| 項目 | 結果 |
+|---|---|
+| 既に他所でホストしているサーバーの掲載 | **可能**。`smithery.ai/new` で公開HTTPS URL を入力するだけ |
+| GitHub リポジトリ | **不要** |
+| `smithery.yaml` | リモートURL登録の場合は不要 |
+| 審査 | 人手の審査は無し。**自動スキャン**が走る（公開サーバーは自動で完了） |
+| 認証 | 認証不要のサーバーはそのままスキャンされる。うちは認証不要 |
+| 任意 | 登録後に Settings → Verification で公式ベンダー認証のチェックリストを進められる |
+
+---
+
+## 2. 判断が必要な点（Fable に相談）
+
+**名前空間をどちらにするか。**
+
+起動文 §3 の「やらないこと」に **`Cloudflare カスタムドメイン・DNS 変更`** があり、§4 の止める条件に
+**「レジストリの要件が『独自ドメインの所有確認』を含む」** がある。ドメイン認証はまさにこれに当たる。
+
+| | `io.github.oo12takemaru-create/ruletrade` | `jp.ruletrade/mcp` |
+|---|---|---|
+| DNS変更 | 不要（起動文の禁止事項に触れない） | **必要**（apex に TXT 1本） |
+| 見え方 | GitHubのユーザー名が名前に出る。ブランド名として弱い | ブランドとして自然。ドメイン所有の裏付けが付く |
+| 後から変更 | **名前は識別子なので、後で変えると別サーバー扱いになる**。利用者の設定は URL 基準なので実害は小さいが、登録は取り直し |
+| リスク | 無し | DNS操作（2026-08-31 に移管失敗の経験あり）。ただし**TXTレコードの追加は移管とは別物で、既存のA/CNAMEには触れない** |
+
+**実務側の所感**: `jp.ruletrade/mcp` の方が資産として良い。TXT レコードの追加は既存レコードを触らないので 08-31 の失敗とは性質が違う。
+ただし DNS を触るかどうかは起動文が明示的に禁じているので、**ここは判断を仰ぐ**。
+
+**GitHub 認証で先に登録して後から変える**のは勧めない。名前が識別子なので、登録し直しになる。
+
+---
+
+## 3. 登録内容の案
+
+`server.github.json` / `server.dns.json` の2案を用意した。**`name` 以外は同一**。
+
+- **name**: 上記の2択
+- **title**: `Rule Trade — Japanese equity verification layer`
+- **description**（英語。エージェントの検索は英語で走る）:
+  > Returns what happened when published, mechanical rules were applied to Japanese equities:
+  > daily rule matches, market regime, and 50 market anomalies tested over 61 years.
+  > Statistics and verdicts only — no price data, no financials, no recommendations.
+- **日本語説明**（Smithery の説明欄など、日本語が入る場所用）:
+  > 日本株の「検証層」。公開ルールに機械的に該当した事実、地合いの機械判定、
+  > ジンクス50本を61年分で検証した結果（判定・勝率・標本数・p値）を返します。
+  > 返すのは判定結果と統計値のみで、価格データ・財務値・売買推奨は含みません。投資助言ではありません。
+- **version**: `0.1.0`
+- **websiteUrl**: `https://ruletrade.jp/`
+- **repository**: `https://github.com/oo12takemaru-create/stock-trading-`（subfolder `mcp`）
+- **remotes**: `streamable-http` → `https://ruletrade.jp/mcp`
+- **カテゴリ/タグ**（入力欄がある場合）: `finance`, `research`, `japan`, `stocks`, `backtesting`
+
+---
+
+## 4. 本人向け手順（名前空間が決まってから）
+
+### A. Smithery（先にこちらを勧める。DNS不要・5分・取り消しも容易）
+
+1. https://smithery.ai/new を開く
+2. URL 欄に `https://ruletrade.jp/mcp` を入力
+3. 表示される公開フローを進める（自動スキャンが走る。認証不要のサーバーなのでそのまま完了する）
+4. 説明欄には上の英語 description、日本語欄があれば日本語版を貼る
+5. 完了後、掲載ページのURLを控える
+
+### B. MCP 公式レジストリ
+
+**B-1. GitHub 認証にする場合（DNS変更なし）**
+
+```
+cd "D:\マイドキュメント\Claude\Projects\stock-trading\mcp\registry"
+copy server.github.json server.json
+npx @modelcontextprotocol/mcp-publisher login github
+```
+→ 表示される `https://github.com/login/device` を開き、ターミナルに出たコード（例 `ABCD-1234`）を入力して承認。
+「Successfully authenticated!」が出たら:
+```
+npx @modelcontextprotocol/mcp-publisher publish
+```
+
+**B-2. ドメイン認証にする場合（DNS の TXT を1本足す）**
+
+先に鍵を作って TXT レコードの文字列を出す（**`key.pem` は秘密鍵。git に入れないこと**）:
+```
+cd "D:\マイドキュメント\Claude\Projects\stock-trading\mcp\registry"
+openssl genpkey -algorithm Ed25519 -out key.pem
+```
+その後、出てきた公開鍵から作った `v=MCPv1; k=ed25519; p=...` という値を
+**`ruletrade.jp` の apex に TXT レコードとして追加**する（サブドメインやセレクタ配下ではダメ）。
+既存の A / CNAME / MX には触らない。反映を待ってから:
+```
+copy server.dns.json server.json
+npx @modelcontextprotocol/mcp-publisher login dns --domain ruletrade.jp --private-key-file key.pem
+npx @modelcontextprotocol/mcp-publisher publish
+```
+
+※ 鍵生成と TXT 文字列の組み立てのコマンドは、その時点の公式手順を実務チャットで再確認してから実行すること
+（レジストリは preview 版で、手順が変わる可能性がある）。
+
+### C. 登録後にやること
+
+- `mcp/HANDOFF.md` と `引継ぎ.md` §17 に、登録先・登録名・掲載URLを追記
+- 呼び出しログ（`event:"tool_call"` の `client`）を見て、レジストリ経由の流入があるか確認する
+
+---
+
+## 5. 注意
+
+- **公式レジストリは preview 版**。「破壊的変更やデータリセットがあり得る」と明記されている。登録が消えることもあり得るので、`server.json` はこのフォルダに残しておく（再登録に使う）。
+- `key.pem`（ドメイン認証を選んだ場合の秘密鍵）は **絶対にコミットしない**。ルート `.gitignore` の `*.pem` を確認すること。

--- a/mcp/registry/server.dns.json
+++ b/mcp/registry/server.dns.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "jp.ruletrade/mcp",
+  "title": "Rule Trade — Japanese equity verification layer",
+  "description": "Returns what happened when published, mechanical rules were applied to Japanese equities: daily rule matches, market regime, and 50 market anomalies tested over 61 years. Statistics and verdicts only — no price data, no financials, no recommendations.",
+  "version": "0.1.0",
+  "websiteUrl": "https://ruletrade.jp/",
+  "repository": {
+    "url": "https://github.com/oo12takemaru-create/stock-trading-",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://ruletrade.jp/mcp"
+    }
+  ]
+}

--- a/mcp/registry/server.github.json
+++ b/mcp/registry/server.github.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.oo12takemaru-create/ruletrade",
+  "title": "Rule Trade — Japanese equity verification layer",
+  "description": "Returns what happened when published, mechanical rules were applied to Japanese equities: daily rule matches, market regime, and 50 market anomalies tested over 61 years. Statistics and verdicts only — no price data, no financials, no recommendations.",
+  "version": "0.1.0",
+  "websiteUrl": "https://ruletrade.jp/",
+  "repository": {
+    "url": "https://github.com/oo12takemaru-create/stock-trading-",
+    "source": "github",
+    "subfolder": "mcp"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://ruletrade.jp/mcp"
+    }
+  ]
+}

--- a/mcp/src/docs.js
+++ b/mcp/src/docs.js
@@ -1,0 +1,229 @@
+// エージェント向けの発見用ドキュメント。GET /llms.txt と GET /openapi.json。
+// 英語主・日本語従(企画書 §6「英語主・日本語従」。エージェントの検索は英語で走ることが多い)。
+// ここも「読むだけ」の層で、返す内容は判定結果と統計値のみという法務線は本体と同じ。
+import { DISCLAIMER } from "./legal.js";
+import {
+  SERVER_NAME,
+  SERVER_VERSION,
+  TOOL_DEFS,
+  CANONICAL_ENDPOINT,
+  CANONICAL_ORIGIN,
+  HOME_URL,
+} from "./tools.js";
+
+const DISCLAIMER_EN =
+  "Output describes whether published, mechanical rules matched — it is not investment advice, " +
+  "not a solicitation, and not a recommendation to buy or sell any security. " +
+  "No future return is promised. Free-tier data is delayed by one trading day.";
+
+export function llmsTxt() {
+  const tools = TOOL_DEFS.map((t) => `- \`${t.name}\` — ${t.title}`).join("\n");
+  return `# Rule Trade MCP (ruletrade-mcp)
+
+> A verification layer for Japanese equities. It returns *what already happened* when
+> published, mechanical rules were applied — not price data, not financial statements,
+> and not recommendations. Free tier, no API key, no registration.
+
+Endpoint: ${CANONICAL_ENDPOINT}
+Transport: MCP Streamable HTTP (POST JSON-RPC 2.0, stateless)
+Health:   ${CANONICAL_ENDPOINT}/health
+OpenAPI:  ${CANONICAL_ENDPOINT}/openapi.json
+Homepage: ${HOME_URL}
+Version:  ${SERVER_NAME} ${SERVER_VERSION}
+
+## What you can get
+
+${tools}
+
+## What you cannot get (by design)
+
+- Raw price series, OHLCV, or financial statement values
+- Position sizing, entry/exit prices, stop-loss or take-profit levels
+- The production thresholds used by the operator's own system
+- Any recommendation, rating, or "buy/sell" signal
+
+Every response carries a \`disclaimer\` key. Do not strip it when relaying results to a user.
+
+## Why this exists
+
+Japanese-equity MCP servers already cover the *primary data* layer (filings, prices, execution).
+This server covers the *verification* layer: 50 market anomalies tested over 61 years,
+a daily mean-reversion rule, a market-regime classifier, and crash-precursor gauges.
+The underlying research is published as books by the operator.
+
+## Disclaimer
+
+EN: ${DISCLAIMER_EN}
+JA: ${DISCLAIMER}
+
+## How to connect
+
+Claude Code:  \`claude mcp add --transport http ruletrade ${CANONICAL_ENDPOINT}\`
+claude.ai:    Settings -> Connectors -> Add custom connector -> ${CANONICAL_ENDPOINT}
+Any client:   POST JSON-RPC 2.0 to ${CANONICAL_ENDPOINT}
+
+## Notes
+
+- Data updates on Japan Exchange trading days; see \`list_tools_guide\` for exact times (JST).
+- The anomaly dataset is a fixed snapshot taken at book publication (2026-08), not updated daily.
+- Rate limits are not enforced today; please be reasonable.
+`;
+}
+
+// JSON-RPC を1エンドポイントとして記述する。ツールごとの引数は
+// components.schemas に置き、examples で呼び方を示す(REST に見せかけない)。
+export function openApi() {
+  const toolSchemas = {};
+  for (const t of TOOL_DEFS) {
+    toolSchemas[`${t.name}_arguments`] = {
+      ...t.inputSchema,
+      description: t.description,
+    };
+  }
+
+  const examples = {};
+  for (const t of TOOL_DEFS) {
+    examples[t.name] = {
+      summary: t.title,
+      value: {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/call",
+        params: { name: t.name, arguments: {} },
+      },
+    };
+  }
+  examples.tools_list = {
+    summary: "List the available tools",
+    value: { jsonrpc: "2.0", id: 1, method: "tools/list", params: {} },
+  };
+  examples.anomaly_by_name = {
+    summary: "Look up one anomaly by name (partial match)",
+    value: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: "get_anomaly_summary", arguments: { name: "セルインメイ" } },
+    },
+  };
+
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Rule Trade MCP (free tier)",
+      version: SERVER_VERSION,
+      summary: "Verification layer for Japanese equities. Returns rule-match facts and statistics only.",
+      description:
+        `${DISCLAIMER_EN}\n\n${DISCLAIMER}\n\n` +
+        "This is an MCP server. The single POST endpoint speaks JSON-RPC 2.0 " +
+        "(methods: initialize, tools/list, tools/call, ping). It is described here so that " +
+        "agents and crawlers can discover the tool surface; it is not a REST API.",
+      contact: { url: HOME_URL },
+    },
+    servers: [{ url: CANONICAL_ORIGIN }],
+    paths: {
+      "/mcp": {
+        post: {
+          operationId: "mcpJsonRpc",
+          summary: "MCP Streamable HTTP endpoint (JSON-RPC 2.0, stateless)",
+          description:
+            "Send a JSON-RPC 2.0 request. Use method `tools/list` to enumerate tools, " +
+            "then `tools/call` with `params.name` and `params.arguments`. Batch arrays are accepted. " +
+            "Every successful tool result includes a `disclaimer` key that must not be removed.",
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/JsonRpcRequest" },
+                examples,
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: "JSON-RPC response. Tool output is in `result.structuredContent`.",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/JsonRpcResponse" } } },
+            },
+            202: { description: "Notification accepted (no response body)." },
+            400: { description: "Malformed JSON." },
+          },
+        },
+        get: {
+          operationId: "mcpGetNotAllowed",
+          summary: "Not allowed — this endpoint is POST only (no SSE stream)",
+          responses: { 405: { description: "Method Not Allowed" } },
+        },
+      },
+      "/mcp/health": {
+        get: {
+          operationId: "health",
+          summary: "Check that every upstream JSON file is reachable",
+          responses: {
+            200: { description: "All source files readable (`ok: true`)." },
+            503: { description: "At least one source file could not be read." },
+          },
+        },
+      },
+      "/mcp/llms.txt": {
+        get: {
+          operationId: "llmsTxt",
+          summary: "Plain-text description of this server for agents",
+          responses: { 200: { description: "text/plain" } },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        JsonRpcRequest: {
+          type: "object",
+          required: ["jsonrpc", "method"],
+          properties: {
+            jsonrpc: { const: "2.0" },
+            id: { type: ["string", "number"], description: "Omit for notifications." },
+            method: {
+              type: "string",
+              enum: ["initialize", "tools/list", "tools/call", "ping", "notifications/initialized"],
+            },
+            params: { type: "object" },
+          },
+        },
+        JsonRpcResponse: {
+          type: "object",
+          properties: {
+            jsonrpc: { const: "2.0" },
+            id: { type: ["string", "number", "null"] },
+            result: {
+              type: "object",
+              properties: {
+                isError: { type: "boolean" },
+                content: {
+                  type: "array",
+                  items: { type: "object", properties: { type: { const: "text" }, text: { type: "string" } } },
+                },
+                structuredContent: { $ref: "#/components/schemas/ToolResult" },
+              },
+            },
+            error: {
+              type: "object",
+              properties: { code: { type: "integer" }, message: { type: "string" } },
+            },
+          },
+        },
+        ToolResult: {
+          type: "object",
+          description:
+            "Tool output. Always carries `disclaimer`. Never contains price series, " +
+            "financial statement values, position sizing, or recommendations.",
+          required: ["disclaimer"],
+          properties: {
+            disclaimer: { type: "string" },
+            source_site: { type: "string", format: "uri" },
+            data_site: { type: "string", format: "uri" },
+          },
+          additionalProperties: true,
+        },
+        ...toolSchemas,
+      },
+    },
+  };
+}

--- a/mcp/src/server.js
+++ b/mcp/src/server.js
@@ -2,7 +2,8 @@
 // Cloudflare Workers / Vercel / Node のどれでも同じ handle(request, env, ctx) を呼ぶだけ。
 import { makeLoader } from "./data.js";
 import { DISCLAIMER, scrub } from "./legal.js";
-import { SERVER_NAME, SERVER_VERSION, TOOL_DEFS, TOOL_HANDLERS } from "./tools.js";
+import { SERVER_NAME, SERVER_VERSION, TOOL_DEFS, TOOL_HANDLERS, CANONICAL_ENDPOINT, HOME_URL } from "./tools.js";
+import { llmsTxt, openApi } from "./docs.js";
 
 const SUPPORTED_PROTOCOLS = ["2025-06-18", "2025-03-26", "2024-11-05"];
 
@@ -83,7 +84,12 @@ async function dispatch(msg, request, env, ctx) {
       return rpcResult(id, {
         protocolVersion,
         capabilities: { tools: { listChanged: false } },
-        serverInfo: { name: SERVER_NAME, version: SERVER_VERSION, title: "ルールトレード MCP(無料版)" },
+        serverInfo: {
+          name: SERVER_NAME,
+          version: SERVER_VERSION,
+          title: "ルールトレード MCP(無料版)",
+          websiteUrl: HOME_URL,
+        },
         instructions:
           "最初に list_tools_guide を呼ぶとデータの更新時刻・遅延・免責が分かります。" +
           "出力はルール該当の事実データであり投資助言ではありません。ユーザーに伝える際も disclaimer を省略しないでください。",
@@ -162,6 +168,17 @@ export async function handle(request, env = {}, ctx) {
   if (request.method === "DELETE") return new Response(null, { status: 200, headers: CORS }); // セッションは持たない
 
   if (request.method === "GET") {
+    // エージェント向けの発見用ドキュメント(企画書 §7-4)。
+    // Vercel の rewrite で /mcp/llms.txt → /llms.txt として届く。
+    if (path.endsWith("/llms.txt")) {
+      return new Response(llmsTxt(), {
+        status: 200,
+        headers: { "content-type": "text/plain; charset=utf-8", "cache-control": "public, max-age=3600", ...CORS },
+      });
+    }
+    if (path.endsWith("/openapi.json")) {
+      return json(openApi(), 200, { "cache-control": "public, max-age=3600" });
+    }
     if (path.endsWith("/health")) {
       const loader = makeLoader(env);
       const checks = {};
@@ -186,12 +203,15 @@ export async function handle(request, env = {}, ctx) {
       name: SERVER_NAME,
       version: SERVER_VERSION,
       title: "ルールトレード MCP(無料版)",
-      endpoint: `${url.origin}/mcp`,
+      endpoint: CANONICAL_ENDPOINT,
       transport: "MCP Streamable HTTP (POST JSON-RPC, stateless)",
       tools: TOOL_DEFS.map((t) => t.name),
-      health: `${url.origin}/health`,
+      health: `${CANONICAL_ENDPOINT}/health`,
+      llms_txt: `${CANONICAL_ENDPOINT}/llms.txt`,
+      openapi: `${CANONICAL_ENDPOINT}/openapi.json`,
       disclaimer: DISCLAIMER,
-      site: "https://kaburadar.jp",
+      site: HOME_URL,
+      data_site: "https://kaburadar.jp",
     });
   }
 

--- a/mcp/src/tools.js
+++ b/mcp/src/tools.js
@@ -4,6 +4,13 @@ import { DISCLAIMER } from "./legal.js";
 export const SERVER_NAME = "ruletrade-mcp";
 export const SERVER_VERSION = "0.1.0";
 
+// 正規URL。ruletrade.jp(Vercel)から Cloudflare Workers へ rewrite している。
+// Worker 側から見た url.origin は workers.dev のままなので、定数で持つ。
+// 配信先を変えるときは vercel.json の1行と、ここ(または環境変数 PUBLIC_ORIGIN)だけ直す。
+export const CANONICAL_ORIGIN = "https://ruletrade.jp";
+export const CANONICAL_ENDPOINT = `${CANONICAL_ORIGIN}/mcp`;
+export const HOME_URL = "https://ruletrade.jp/";
+
 const REGIME_LABEL = {
   BULLISH: "強気",
   NEUTRAL: "中立",
@@ -179,7 +186,12 @@ export const TOOL_DEFS = [
 
 // ---- 各ツールの実装 ------------------------------------------------------
 function meta(extra) {
-  return { disclaimer: DISCLAIMER, source_site: "https://kaburadar.jp", ...extra };
+  return {
+    disclaimer: DISCLAIMER,
+    source_site: HOME_URL,          // ルール・検証の公開元
+    data_site: "https://kaburadar.jp", // 日次データ(地合い・傾斜計・着火メーター)の公開元
+    ...extra,
+  };
 }
 
 async function getDailySignals(args, { load }) {
@@ -400,7 +412,13 @@ async function getAnomalySummary(args, { load, env }) {
 
 async function listToolsGuide() {
   return meta({
-    server: { name: SERVER_NAME, version: SERVER_VERSION, tier: "free" },
+    server: {
+      name: SERVER_NAME,
+      version: SERVER_VERSION,
+      tier: "free",
+      endpoint: CANONICAL_ENDPOINT,
+      homepage: HOME_URL,
+    },
     what_this_is:
       "kaburadar.jp / ruletrade.jp が公開している検証済みルールの実行結果(JSON)を、AIエージェントから読める形に変換するだけのサーバー。売買エンジンや発注機能は持たない。",
     tools: TOOL_DEFS.map((t) => ({ name: t.name, title: t.title, description: t.description })),
@@ -433,7 +451,7 @@ async function listToolsGuide() {
       policy: "推奨・おすすめ等の表現は出力から除外する。免責は全レスポンスに常設する。",
       license: "個人利用向け。再配布・商用利用は要相談",
     },
-    contact: "https://kaburadar.jp",
+    contact: HOME_URL,
   });
 }
 

--- a/mcp/test/server.test.js
+++ b/mcp/test/server.test.js
@@ -244,12 +244,71 @@ test("データ取得失敗は isError=true で返す(サーバーは落ちな�
 test("GET / と /health と /mcp(405)", async () => {
   const root = await handle(new Request("https://x.test/"), {});
   assert.equal(root.status, 200);
-  assert.equal((await root.json()).endpoint, "https://x.test/mcp");
+  // 案内する URL は常に正規URL。Vercel の rewrite 経由だと Worker から見た
+  // オリジンは workers.dev のままなので、リクエストのホストを混ぜてはいけない
+  const rootBody = await root.json();
+  assert.equal(rootBody.endpoint, "https://ruletrade.jp/mcp");
+  assert.equal(rootBody.health, "https://ruletrade.jp/mcp/health");
+  assert.equal(rootBody.site, "https://ruletrade.jp/");
   const h = await handle(new Request("https://x.test/health"), {});
   assert.equal(h.status, 200);
   assert.equal((await h.json()).ok, true);
   const m = await handle(new Request("https://x.test/mcp"), {});
   assert.equal(m.status, 405);
+});
+
+test("案内する URL が正規URL(ruletrade.jp)に統一されている", async () => {
+  // initialize の serverInfo
+  const { body } = await rpc("initialize", { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: "t", version: "1" } });
+  assert.equal(body.result.serverInfo.websiteUrl, "https://ruletrade.jp/");
+
+  // list_tools_guide
+  const g = (await call("list_tools_guide")).structuredContent;
+  assert.equal(g.server.endpoint, "https://ruletrade.jp/mcp");
+  assert.equal(g.server.homepage, "https://ruletrade.jp/");
+  assert.equal(g.contact, "https://ruletrade.jp/");
+
+  // 全ツールに source_site / data_site が付く
+  for (const name of ["get_daily_signals", "get_market_regime", "get_anomaly_summary", "list_tools_guide"]) {
+    const p = (await call(name)).structuredContent;
+    assert.equal(p.source_site, "https://ruletrade.jp/", name);
+    assert.equal(p.data_site, "https://kaburadar.jp", name);
+  }
+
+  // workers.dev を案内していない(配信先が変わっても利用者側が壊れないようにするため)
+  for (const name of ["list_tools_guide", "get_daily_signals"]) {
+    const t = (await call(name)).content[0].text;
+    assert.equal(t.includes("workers.dev"), false, `${name} が workers.dev を案内している`);
+  }
+});
+
+test("llms.txt と openapi.json(エージェント向けの発見用)", async () => {
+  const t = await handle(new Request("https://x.test/llms.txt"), {});
+  assert.equal(t.status, 200);
+  assert.match(t.headers.get("content-type"), /^text\/plain/);
+  const txt = await t.text();
+  assert.ok(txt.includes("https://ruletrade.jp/mcp"), "正規URLが書かれていない");
+  assert.equal(txt.includes("workers.dev"), false, "workers.dev を案内している");
+  for (const name of ["get_daily_signals", "get_market_regime", "get_anomaly_summary", "list_tools_guide"]) {
+    assert.ok(txt.includes(name), `${name} が載っていない`);
+  }
+  assert.ok(/not investment advice/i.test(txt), "英語の免責がない");
+  assert.equal(hasNg(txt), false, "llms.txt に推奨語がある");
+
+  const o = await handle(new Request("https://x.test/openapi.json"), {});
+  assert.equal(o.status, 200);
+  assert.match(o.headers.get("content-type"), /^application\/json/);
+  const spec = await o.json();
+  assert.equal(spec.openapi, "3.1.0");
+  assert.equal(spec.servers[0].url, "https://ruletrade.jp");
+  assert.ok(spec.paths["/mcp"].post, "/mcp の POST が記述されていない");
+  assert.equal(spec.paths["/mcp"].get.responses["405"] !== undefined, true);
+  // ツール4本ぶんの引数スキーマが載っている
+  for (const name of ["get_daily_signals", "get_market_regime", "get_anomaly_summary", "list_tools_guide"]) {
+    assert.ok(spec.components.schemas[`${name}_arguments`], `${name} のスキーマがない`);
+  }
+  assert.ok(spec.components.schemas.ToolResult.required.includes("disclaimer"));
+  assert.equal(hasNg(JSON.stringify(spec)), false, "openapi.json に推奨語がある");
 });
 
 test("バッチ要求", async () => {


### PR DESCRIPTION
起動文 `起動文_実務_MCP公開後仕上げ_2026-09-05.md` の Step 1〜5。**読むだけの変換層のまま。生成側 Python・既存ワークフローは無変更。**

## 1. 正規URLを `https://ruletrade.jp/mcp` に統一

ruletrade.jp（Vercel の静的サイト）に `vercel.json` を新設し、`/mcp` を Cloudflare Workers へ rewrite（外部プロキシ）した。**DNS は変更していない。**

```
利用者 → https://ruletrade.jp/mcp  (Vercel の rewrite)
             ↓
       https://ruletrade-mcp.<account>.workers.dev/mcp  (Worker 実体)
```

Worker を引っ越しても `site/vercel.json` の2行を直すだけで、レジストリ登録も利用者側の設定も変わらない。ログは Worker 側にそのまま残る。

**落とし穴**: rewrite 経由だと Worker から見た `url.origin` は workers.dev のまま。案内する URL をリクエストのホストから組み立てると workers.dev が漏れる。そこで `CANONICAL_ORIGIN` / `CANONICAL_ENDPOINT` / `HOME_URL` を定数化し、**出力に `workers.dev` が現れないことをテストで機械検査**している。

- `initialize` の `serverInfo` に `websiteUrl`
- `list_tools_guide` に `server.endpoint` / `server.homepage`
- 全ツールの返却に `source_site`（ruletrade.jp＝ルールの公開元）と `data_site`（kaburadar.jp＝日次データの公開元）

本番で確認済み: `POST /mcp` の `tools/list`・`tools/call`（引数つき）、`GET /mcp/health` = `ok:true`、`GET /mcp` = 405、既存の静的ページも無傷。`claude mcp add --transport http ruletrade https://ruletrade.jp/mcp` で `✔ Connected`。

## 2. 発見用ドキュメント（企画書 §7-4）

`src/docs.js` を追加。

- `GET /llms.txt` — 英語主・日本語従。取れるもの／取れないもの／接続方法／免責。
- `GET /openapi.json` — OpenAPI 3.1。実体は JSON-RPC なので `/mcp` の POST を1エンドポイントとして記述し、ツールごとの引数スキーマと呼び出し例を `components` / `examples` に置いた。REST に見せかけていない。

サイト側にも `site/llms.txt` を追加（`robots.txt` は触っていない）。

## 3. 英語ドキュメント（企画書 §7-2）

`README.md` を英日併記に（英語が先）。エージェントの検索は英語で走ることが多いため。**取れないもの**（価格系列・財務値・建玉サイズ・推奨）を明示的に列挙した。

## 4. レジストリ登録は「準備まで」

**登録操作は行っていない。** `mcp/registry/` に要件調査・登録内容の案・本人向け手順を置いた。

- リモートHTTPサーバーはどちらのレジストリも登録可能。**npm 等へのパッケージ公開は不要**（所有権検証は `packages` を書いた場合の話）。
- 公式レジストリは **preview 版**。人手の審査は無し。
- 名前空間の認証が2択で、**DNS を触るかどうかの判断が残っている**（起動文 §3 の「やらないこと」に DNS 変更があるため）。`server.github.json`（DNS不要）と `server.dns.json`（apex に TXT が必要）の2案を用意した。

`.gitignore` に `*.pem` を追加（ドメイン認証を選んだ場合の秘密鍵をコミットしないため）。

## テスト

16 → 18 本、全 pass。追加分は「正規URLの一貫性」「llms.txt / openapi.json の 200・content-type・推奨語ゼロ」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
