### PR TITLE
MCP: llms.txt のツール一覧を英語にする（本番確認で日本語混在を発見）

### DIFF
--- a/mcp/src/docs.js
+++ b/mcp/src/docs.js
@@ -16,8 +16,26 @@ const DISCLAIMER_EN =
   "not a solicitation, and not a recommendation to buy or sell any security. " +
   "No future return is promised. Free-tier data is delayed by one trading day.";
 
+// llms.txt は英語圏のエージェントに読ませるためのもの。TOOL_DEFS の title は
+// 日本語なので流用せず、英語の1行説明をここに持つ(ツールを増やしたらここも足す)。
+const TOOL_LINES_EN = {
+  get_daily_signals:
+    "Stocks that matched the published mean-reversion rule (25-day moving-average deviation), " +
+    "plus near-miss watch candidates. One trading day delayed, top 3 by deviation.",
+  get_market_regime:
+    "Machine-classified market regime (BULLISH / NEUTRAL / BEARISH / PANIC), circuit-breaker state, " +
+    "VIX, Nikkei 225, and optional daily history. No stock names.",
+  get_anomaly_summary:
+    "50 Japanese market anomalies tested over 61 years - verdict, win rate, mean return, sample size, " +
+    "p-value. Filter by `name`. Plus five crash-precursor gauges and a 7-flag ignition meter.",
+  list_tools_guide:
+    "Update times (JST), data delays, free-tier limits, disclaimer, and roadmap. Call this first.",
+};
+
 export function llmsTxt() {
-  const tools = TOOL_DEFS.map((t) => `- \`${t.name}\` — ${t.title}`).join("\n");
+  const tools = TOOL_DEFS.map(
+    (t) => `- \`${t.name}\` — ${TOOL_LINES_EN[t.name] || t.title}`,
+  ).join("\n");
   return `# Rule Trade MCP (ruletrade-mcp)
 
 > A verification layer for Japanese equities. It returns *what already happened* when

--- a/mcp/test/server.test.js
+++ b/mcp/test/server.test.js
@@ -293,6 +293,17 @@ test("llms.txt と openapi.json(エージェント向けの発見用)", async ()
     assert.ok(txt.includes(name), `${name} が載っていない`);
   }
   assert.ok(/not investment advice/i.test(txt), "英語の免責がない");
+  // ツール一覧は英語で書く(英語圏のエージェントに読ませるためのファイルなので、
+  // TOOL_DEFS の日本語 title を流用しない)
+  const toolBlock = txt.split("## What you can get")[1].split("##")[0];
+  assert.equal(/[ぁ-んァ-ン一-龥]/.test(toolBlock), false, "ツール一覧に日本語が混ざっている");
+  for (const name of ["get_daily_signals", "get_market_regime", "get_anomaly_summary", "list_tools_guide"]) {
+    const line = toolBlock.split("\n").find((l) => l.startsWith("- " + `\`${name}\`` + " — "));
+    assert.ok(line, `${name} の行がない`);
+    const desc = line.split(" — ")[1] || "";
+    assert.ok(desc.trim().length > 30, `${name} の英語説明が短すぎる: ${desc}`);
+    assert.equal(/[ぁ-んァ-ン一-龥]/.test(desc), false, `${name} の説明に日本語`);
+  }
   assert.equal(hasNg(txt), false, "llms.txt に推奨語がある");
 
   const o = await handle(new Request("https://x.test/openapi.json"), {});


### PR DESCRIPTION
本番デプロイ後の目視で見つけた不整合の修正。

`llms.txt` は英語圏のエージェントに読ませるためのファイル（企画書 §7-2「エージェントの検索は英語で走る」）だが、**ツール一覧だけ日本語**になっていた。`TOOL_DEFS` の `title` をそのまま流用していたため。

```
Before:
- `get_market_regime` — 地合い判定(BULLISH/NEUTRAL/BEARISH/PANIC)

After:
- `get_market_regime` — Machine-classified market regime (BULLISH / NEUTRAL / BEARISH / PANIC),
  circuit-breaker state, VIX, Nikkei 225, and optional daily history. No stock names.
```

- `src/docs.js` に `TOOL_LINES_EN` を追加。ツールを増やしたらここも足す（無ければ `title` にフォールバックするので壊れない）。
- MCP プロトコル側の `title`（日本語）は変更していない。クライアントUIに出るのはそちらで、日本語のままが正しい。
- テストで「ツール一覧に日本語が混ざらないこと」「各ツールに実のある英語説明があること」を検査。18本 全pass。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
