### PR TITLE
MCP registry: description を100文字制限に合わせる（登録完了・jp.ruletrade/mcp）

### DIFF
--- a/mcp/registry/server.dns.json
+++ b/mcp/registry/server.dns.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "jp.ruletrade/mcp",
-  "title": "Rule Trade — Japanese equity verification layer",
-  "description": "Returns what happened when published, mechanical rules were applied to Japanese equities: daily rule matches, market regime, and 50 market anomalies tested over 61 years. Statistics and verdicts only — no price data, no financials, no recommendations.",
+  "title": "Rule Trade - Japanese equity verification layer",
+  "description": "Japanese equity verification layer. Rule matches, market regime, 50 anomalies tested over 61 years.",
   "version": "0.1.0",
   "websiteUrl": "https://ruletrade.jp/",
   "repository": {

--- a/mcp/registry/server.github.json
+++ b/mcp/registry/server.github.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.oo12takemaru-create/ruletrade",
-  "title": "Rule Trade — Japanese equity verification layer",
-  "description": "Returns what happened when published, mechanical rules were applied to Japanese equities: daily rule matches, market regime, and 50 market anomalies tested over 61 years. Statistics and verdicts only — no price data, no financials, no recommendations.",
+  "title": "Rule Trade - Japanese equity verification layer",
+  "description": "Japanese equity verification layer. Rule matches, market regime, 50 anomalies tested over 61 years.",
   "version": "0.1.0",
   "websiteUrl": "https://ruletrade.jp/",
   "repository": {


### PR DESCRIPTION
ドキュメント/設定のみ。**2026-09-05 に公式レジストリへの登録が完了した**（`jp.ruletrade/mcp` 0.1.0・`status: active`）際に判明した制約の反映。

## 何が起きたか

`mcp-publisher publish` が 422 で落ちた。

```
{"status":422,"detail":"validation failed",
 "errors":[{"message":"expected length <= 100","location":"body.description"}]}
```

`registry.modelcontextprotocol.io` は `description` と `title` に **maxLength=100** の制約がある。用意していた説明文は250文字あった。

その場しのぎで縮めず、`server.schema.json` を取得して**全フィールドの制約を洗い出し、機械で検証してから**差し替えた。

| 項目 | 制約 | 修正後 |
|---|---|---|
| `description` | 1〜100 | 99 |
| `title` | 1〜100 | 47 |
| `name` | 3〜200・`^[a-zA-Z0-9.-]+/[a-zA-Z0-9._-]+$` | `jp.ruletrade/mcp` |
| `version` | ≤255 | `0.1.0` |

## 判断したこと

- 100文字では「価格・財務値・推奨を返さない」「投資助言ではない」が入らないので落とした。**`llms.txt`・OpenAPI・全レスポンスの `disclaimer` には入っているので法務線は保たれている。**
- `title` の em ダッシュ（—）をハイフンに変更。CLI・レジストリ側での文字化けを避けるため。
- `server.github.json`（不採用の退避案）も同じ文言に揃えた。

## 登録結果

```
name: jp.ruletrade/mcp   version: 0.1.0   status: active
remotes: streamable-http -> https://ruletrade.jp/mcp
```

`https://registry.modelcontextprotocol.io/v0/servers?search=ruletrade` で確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
