### PR TITLE
ci: 公開数字の JSON をキャッシュ温めより先に出す（日次の必須部分を約3分に）

### DIFF
--- a/.github/workflows/precompute-daily.yml
+++ b/.github/workflows/precompute-daily.yml
@@ -74,14 +74,12 @@ jobs:
       # ★キャッシュのキーは TypeScript 側（params.ts）と一致している必要がある。
       #   ズレるとエラーにならず「毎回遅い」だけなので、
       #   precompute/tests/verify_cache_key.py で確かめること。
-      - name: Warm preset adjustment cache
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          set -o pipefail
-          python precompute/warm_cache.py | tee -a update.log
-
+      # ★順序（2026-09-06 Fable）★
+      # 公開数字の JSON は、調整域のキャッシュ温めに依存させない。
+      # 温めは 40〜50分かかるが、JSON に必要なのは Rebuild までなので
+      # 先に公開し、温めは最後に回す。温めが落ちても JSON は出る。
+      # 温めが90分を超えるようなら、別ワークフロー（夜間・単独）に切り出し、
+      # 日次の必須部分（metrics → rebuild → publish）は10分以内を保つ。
       # 公開数字を1枚の JSON にして GitHub Pages で配る。
       # 静的サイト（ruletrade.jp）と会員アプリ /dashboard がこの同じ値を見る
       # ＝「一つの定義・一つの数字」（引継ぎ.md §19・起動文 2-4c）。
@@ -112,6 +110,16 @@ jobs:
           done
           echo "::error::3回試行してもpushできませんでした"
           exit 1
+
+      # 調整域のキャッシュ温め（最後に回す。ここが落ちても公開数字は出ている）
+      # スライダーの体感を良くするためのもので、正しさには関わらない。
+      - name: Warm preset adjustment cache
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -o pipefail
+          python precompute/warm_cache.py | tee -a update.log
 
       - name: Write summary
         if: always()

--- a/.github/workflows/precompute-monthly.yml
+++ b/.github/workflows/precompute-monthly.yml
@@ -68,14 +68,10 @@ jobs:
       # ★キャッシュのキーは TypeScript 側（params.ts）と一致している必要がある。
       #   ズレるとエラーにならず「毎回遅い」だけなので、
       #   precompute/tests/verify_cache_key.py で確かめること。
-      - name: Warm preset adjustment cache
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          set -o pipefail
-          python precompute/warm_cache.py | tee -a build.log
-
+      # ★順序（2026-09-06 Fable）★
+      # 公開数字の JSON は、調整域のキャッシュ温めに依存させない。
+      # 月次は全期間の再計算のあとなので、まず JSON を出してから温める。
+      # （温めは「再計算 → 温め直し」の順を守る必要があるので、月次でも最後）
       # 公開数字を1枚の JSON にして GitHub Pages で配る。
       # 静的サイト（ruletrade.jp）と会員アプリ /dashboard がこの同じ値を見る
       # ＝「一つの定義・一つの数字」（引継ぎ.md §19・起動文 2-4c）。
@@ -106,6 +102,16 @@ jobs:
           done
           echo "::error::3回試行してもpushできませんでした"
           exit 1
+
+      # 調整域のキャッシュ温め（最後に回す。ここが落ちても公開数字は出ている）
+      # 月次の全期間再計算のあとにキャッシュを作り直す（起動文 §1-1 の順序）。
+      - name: Warm preset adjustment cache
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+        run: |
+          set -o pipefail
+          python precompute/warm_cache.py | tee -a build.log
 
       - name: Write summary
         if: always()


### PR DESCRIPTION
2026-09-06 Fable の決定。**公開数字の JSON を、調整域のキャッシュ温めより先に出す。**

## なぜ

`docs/portfolio_stats.json` に必要なのは `Rebuild preset portfolio result` までで、調整域の温めは要らない。それなのに温めの後ろに置かれていたため、

- 公開数字の更新が毎日1時間近く遅れる
- **温めが落ちると JSON まで出ない**（本来は無関係なのに巻き添えになる）

今日の手動実行での実測がこうだった。

| ステップ | 所要 |
|---|---|
| Update daily_metrics / market_condition | 1分34秒 |
| Rebuild preset portfolio result | 55秒 |
| **Warm preset adjustment cache** | **40分以上（実行中）** |

## 変更

日次・月次とも `Publish portfolio_stats.json` を `Rebuild` の直後へ移し、`Warm preset adjustment cache` を最後にした。ステップの中身は1行も変えていない。順序だけ。

```
変更前: … → Rebuild → Warm(40〜50分) → Publish → Summary
変更後: … → Rebuild → Publish → Warm(40〜50分) → Summary
```

これで日次の必須部分（metrics → rebuild → publish）は**約3分**になる。温めはスライダーの体感を良くするためのもので、数字の正しさには関わらないので最後で困らない。

月次も「全期間の再計算 → 温め直し」の順を守る必要があるため、そちらでも温めは最後のままにしている。

## 今後の目安

温めが90分を超えるようなら、別ワークフロー（夜間・単独）に切り出し、日次の必須部分は10分以内を保つ。

YAML は PyYAML で構文と最終的なステップ順を確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
