### PR TITLE
fix(precompute): 入力が欠けたまま公開しないようにする（^GSPC 欠損で別物の数字を公開した事故の対策）

### DIFF
--- a/precompute/export_portfolio_json.py
+++ b/precompute/export_portfolio_json.py
@@ -191,6 +191,57 @@ def build(row: dict) -> dict:
     }
 
 
+# 前回公開値との乖離の許容幅（2026-09-06 Fable 相談⑥）。
+# 2026-09-06 に ^GSPC の取得失敗で相場環境が壊れ、トレードが 1,820→1,038 件、
+# 勝率 52.4→53.4% の別物が公開された。数字は「良く」見えたので気づきにくい。
+# 1日で越えるはずのない幅を置き、越えたら**公開しない**（前回のJSONを残す）。
+DRIFT_TRADES_PCT = 10.0   # トレード数の増減
+DRIFT_WIN_RATE_PT = 3.0   # 勝率の増減（ポイント）
+DRIFT_UNIVERSE_DROP = 5   # 実際に計算に使えた銘柄数の「減り」
+
+
+def load_previous(path):
+    """前回公開した JSON。無ければ None（初回は乖離検査をしない）。"""
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (FileNotFoundError, ValueError):
+        return None
+
+
+def drift_errors(new, prev) -> list:
+    """前回公開値と比べて、1日では起きないはずの変化がないか見る。"""
+    if not prev:
+        return []
+    errs = []
+
+    pt, nt = prev.get("trades"), new.get("trades")
+    if isinstance(pt, int) and pt > 0 and isinstance(nt, int):
+        change = abs(nt - pt) / pt * 100
+        if change > DRIFT_TRADES_PCT:
+            errs.append(
+                "トレード数が %d → %d（%.1f%% 変化）。許容は ±%.0f%%"
+                % (pt, nt, change, DRIFT_TRADES_PCT)
+            )
+
+    pw, nw = prev.get("win_rate"), new.get("win_rate")
+    if isinstance(pw, (int, float)) and isinstance(nw, (int, float)):
+        if abs(nw - pw) > DRIFT_WIN_RATE_PT:
+            errs.append(
+                "勝率が %.1f%% → %.1f%%（%.1fpt 変化）。許容は ±%.0fpt"
+                % (pw, nw, nw - pw, DRIFT_WIN_RATE_PT)
+            )
+
+    pu, nu = prev.get("universe_effective"), new.get("universe_effective")
+    if isinstance(pu, int) and isinstance(nu, int) and pu - nu > DRIFT_UNIVERSE_DROP:
+        errs.append(
+            "計算に使えた銘柄が %d → %d（%d 減）。許容は %d まで"
+            % (pu, nu, pu - nu, DRIFT_UNIVERSE_DROP)
+        )
+
+    return errs
+
+
 def validate(d) -> list:
     """公開前の自己点検。1件でも引っかかったら書き出さない。"""
     errs = []
@@ -250,11 +301,32 @@ def validate(d) -> list:
     return errs
 
 
+def _write_summary(errs, payload, prev):
+    """GitHub Actions のジョブ要約に出す（ログを開かなくても気づけるように）。"""
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    try:
+        with open(path, "a", encoding="utf-8") as f:
+            f.write("## 公開数字の更新を止めました\n\n")
+            f.write("前回の `docs/portfolio_stats.json` をそのまま残しています。\n\n")
+            for e in errs:
+                f.write("- %s\n" % e)
+            if prev:
+                f.write("\n| | 前回 | 今回 |\n|---|---|---|\n")
+                for k in ("trades", "win_rate", "pf", "max_dd_pct", "universe_effective"):
+                    f.write("| %s | %s | %s |\n" % (k, prev.get(k), payload.get(k)))
+    except OSError:
+        pass
+
+
 def main():
     p = argparse.ArgumentParser(description="公開数字を docs/portfolio_stats.json に出す")
     p.add_argument("--env-file", default="")
     p.add_argument("--out", default=OUT_PATH)
     p.add_argument("--dry-run", action="store_true")
+    p.add_argument("--allow-drift", action="store_true",
+                   help="前回値との乖離検査を通す（値が本当に変わったと分かっているとき）")
     p.add_argument("--from-json", default="",
                    help="Supabase の代わりに portfolio_results 行の JSON ファイルから作る（検証用）")
     args = p.parse_args()
@@ -281,10 +353,24 @@ def main():
     payload = build(rows[0])
 
     errs = validate(payload)
+
+    # 前回公開値との乖離（相談⑥）。閾値を越えたら**前回のJSONをそのまま残す**。
+    # 空ファイルや途中まで書いたファイルを作らないため、書き出し前に判定する。
+    prev = load_previous(args.out)
+    drift = drift_errors(payload, prev)
+    if drift and not args.allow_drift:
+        errs.extend(drift)
+        errs.append(
+            "前回値から大きく動いています。入力データの欠損を疑ってください"
+            "（^GSPC が取れないと相場環境が壊れます）。"
+            "意図した変化なら --allow-drift を付けて実行してください。"
+        )
+
     if errs:
-        log("検証に失敗したので書き出しません:")
+        log("::error::公開数字の検証に失敗したので書き出しません（前回のJSONを残します）")
         for e in errs:
             log("  - " + e)
+        _write_summary(errs, payload, prev)
         return 1
 
     text = json.dumps(payload, ensure_ascii=False, indent=2) + "\n"

--- a/precompute/fetching.py
+++ b/precompute/fetching.py
@@ -29,6 +29,18 @@ import yfinance as yf  # noqa: E402
 
 from config import CACHE_DIR  # noqa: E402
 
+# yfinance はタイムゾーン情報を SQLite に貯める。既定の場所は共有なので、
+# 同じマシンで別のワークフローと重なると OperationalError('database is locked')
+# になり、その銘柄だけ取得に失敗する。
+# 2026-09-06 にこれで ^GSPC が落ち、相場環境の判定が丸ごと変わった（§19-2）。
+# 実行ごとに独立した場所を使わせて、そもそも競合させない。
+try:
+    _TZ_DIR = os.path.join(CACHE_DIR, "yf_tz")
+    os.makedirs(_TZ_DIR, exist_ok=True)
+    yf.set_tz_cache_location(_TZ_DIR)
+except Exception:  # 古い yfinance にこの関数が無くても止めない
+    pass
+
 OHLCV = ["Open", "High", "Low", "Close", "Volume"]
 
 
@@ -124,6 +136,31 @@ def download_batch(tickers, start, end, auto_adjust, retries=2, pause=1.0):
             break
         time.sleep(pause * (attempt + 1))
     return result
+
+
+def refetch_one(ticker, start, end, auto_adjust, attempts=4, pause=3.0, log=print):
+    """1銘柄だけを、間隔を空けて単独で取り直す。
+
+    `database is locked` のような一過性の失敗はまとめ取りの再試行では抜けにくい。
+    threads を使わず1本ずつ・待ち時間を伸ばして粘る。
+    取れたら DataFrame、ダメなら None。
+    """
+    for i in range(attempts):
+        time.sleep(pause * (i + 1))
+        try:
+            raw = yf.download(ticker, start=start, end=end, progress=False,
+                              auto_adjust=auto_adjust, threads=False)
+        except Exception as e:
+            log("    再取得 %d/%d 失敗: %s" % (i + 1, attempts, e))
+            continue
+        if raw is None or len(raw) == 0:
+            log("    再取得 %d/%d: 空の応答" % (i + 1, attempts))
+            continue
+        df = _normalize(raw)
+        if df is not None and len(df) > 0:
+            log("    再取得 %d/%d 成功（%d 行）" % (i + 1, attempts, len(df)))
+            return df
+    return None
 
 
 def get_prices(tickers, start, end, auto_adjust=True, kind="prices",

--- a/precompute/pipeline.py
+++ b/precompute/pipeline.py
@@ -13,6 +13,7 @@ import pandas as pd
 
 import config
 import metrics
+import fetching
 from fetching import get_prices
 from universe import JAPAN_STOCKS
 
@@ -47,7 +48,30 @@ def run_pipeline(tickers=None, years: int = config.DEFAULT_YEARS,
                                     auto_adjust=auto_adjust, kind="global",
                                     refresh=refresh, log=log)
     if gfail:
-        log("  ★グローバル指数の取得に失敗: %s（相場環境の判定精度が落ちる）" % gfail)
+        # ★ここで止める理由（2026-09-06 に実際に踏んだ・§19-2）★
+        # 相場環境(regime)は ^N225 と ^GSPC から決まる。^GSPC が欠けると
+        # BULLISH が一度も立たず、BULLISH でしか動かないモメンタム戦略が
+        # 丸ごと消える。実際に 1,820件→1,038件・PF1.54→1.78 と、
+        # 「精度が落ちる」ではなく**別物の数字**が公開された。
+        # まず単独で粘って取り直し、それでもダメなら計算せずに止める。
+        log("  ★グローバル指数の取得に失敗: %s → 単独で取り直します" % gfail)
+        still = []
+        for t in gfail:
+            df = fetching.refetch_one(t, start, end, auto_adjust, log=log)
+            if df is None:
+                still.append(t)
+            else:
+                fetching.save_cache(t, df, auto_adjust, "global")
+                global_data[t] = df
+        if still:
+            raise SystemExit(
+                "グローバル指数 %s を取得できませんでした。\n"
+                "  相場環境の判定がこれに依存しているため、欠けたまま計算すると"
+                "別物の数字になります。公開しないでここで止めます。\n"
+                "  時間をおいて再実行してください（一過性の失敗であることが多い）。"
+                % ", ".join(still)
+            )
+        log("  ★取り直しに成功しました: %s" % ", ".join(gfail))
 
     log("[2/4] 個別株を取得")
     prices, failed = get_prices(tickers, start, end, auto_adjust=auto_adjust,


### PR DESCRIPTION
2026-09-06 Fable 相談⑥。**壊れた数字を公開してしまった事故**の対策。提案1〜3をすべて実装した。

## 何が起きたか

日次バッチ（run 34030084497）は **success で終わったのに、公開された数字が別物**だった。

```
['^GSPC']: OperationalError('database is locked')
★グローバル指数の取得に失敗: ['^GSPC']（相場環境の判定精度が落ちる）
```

S&P500 が一時的な SQLite ロックで取れず、**警告を出しただけで計算を続けた。**

| | 06:00Z（正常） | 11:24Z（公開されたもの） |
|---|---|---|
| 相場環境 | BULLISH 1405 / BEARISH 757 / NEUTRAL 272 / PANIC 28 | **BULLISH 0** / BEARISH 757 / NEUTRAL 1677 / PANIC 28 |
| momentum-breakout | 1,078件 | **0件** |
| 合計 | 1,820件・52.4%・PF1.54・DD−24.2% | 1,038件・53.4%・PF1.78・DD−19.2% |

相場環境は `^N225` と `^GSPC` から決まる。`^GSPC` が欠けると BULLISH が一度も立たず、**BULLISH でしか動かないモメンタム戦略が丸ごと消える**。「精度が落ちる」ではなく別物になる。

しかも **PF が 1.54→1.78 と「良く」なる**ので、数字だけ見ても異常に気づけない。

## 対策1: そもそも競合させない（`fetching.py`）

yfinance のタイムゾーンDB（SQLite）は既定の場所が共有で、同じマシンの別ワークフローと重なるとロックする。実行ごとに独立した場所を使わせる。

## 対策2: 取れなければ止める（`pipeline.py`）

グローバル指数が落ちたら、**単独・間隔を空けて4回まで**取り直す（`refetch_one`。まとめ取りの再試行では一過性のロックを抜けにくいため、`threads=False` で1本ずつ）。それでも取れなければ `SystemExit` で止める。**計算も公開もさせない。**

## 対策3: 公開前に前回値と比べる（`export_portfolio_json.py`）

| 項目 | 許容 |
|---|---|
| トレード数 | ±10% |
| 勝率 | ±3pt |
| 計算に使えた銘柄数の減り | 5まで |

越えたら**書き出さず、前回の JSON をそのまま残す**（空ファイルや部分更新を作らないよう、書き出し前に判定する）。`GITHUB_STEP_SUMMARY` に前回・今回の対比表を書き、`exit 1` で落とす。

値が本当に変わったと分かっているときは `--allow-drift`。

## 確認したこと

今回の壊れた値を実際に流して確かめた。

```
トレード数が 1820 → 1038（43.0% 変化）。許容は ±10%
→ exit 1 / 前回JSONは1バイトも変わらない
→ --allow-drift を付けると通る（exit 0）
```

## 残っていること

**いま main にある `docs/portfolio_stats.json` と Supabase の `portfolio_results` は壊れた値のまま。** この PR をマージしてから日次バッチを流し直して、正しい値に戻す必要がある。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
