### PR TITLE
ci: 復旧用に allow_drift の手動スイッチを足す（乖離検査が復旧まで止めてしまう）

### DIFF
--- a/.github/workflows/precompute-daily.yml
+++ b/.github/workflows/precompute-daily.yml
@@ -17,6 +17,11 @@ on:
         description: '直近何営業日ぶんを upsert するか'
         required: false
         default: '5'
+      allow_drift:
+        description: '前回公開値との乖離検査を通す（壊れた値から復旧するときだけ true）'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -74,6 +79,10 @@ jobs:
       # ★キャッシュのキーは TypeScript 側（params.ts）と一致している必要がある。
       #   ズレるとエラーにならず「毎回遅い」だけなので、
       #   precompute/tests/verify_cache_key.py で確かめること。
+      # ★allow_drift について★
+      # 乖離検査（前回公開値と比べて trades ±10% 等）は、壊れた値が一度
+      # 公開されると「正しい値に戻す」方向も止めてしまう。
+      # 復旧のときだけ手動実行で allow_drift=true を選ぶ。既定は false。
       # ★順序（2026-09-06 Fable）★
       # 公開数字の JSON は、調整域のキャッシュ温めに依存させない。
       # 温めは 40〜50分かかるが、JSON に必要なのは Rebuild までなので
@@ -94,7 +103,7 @@ jobs:
           for i in 1 2 3; do
             git fetch origin ${{ github.ref_name }}
             git reset --hard origin/${{ github.ref_name }}
-            python precompute/export_portfolio_json.py
+            python precompute/export_portfolio_json.py ${{ inputs.allow_drift && '--allow-drift' || '' }}
             git add -f docs/portfolio_stats.json
             if git diff --staged --quiet; then
               echo "変更なし → 完了"


### PR DESCRIPTION
乖離検査（PR #366）は**正しく働いた**。ただし復旧を通す手段が無かったので足す。

## 実際に起きたこと

復旧のために日次バッチを流し直した（run 34119944675）。

**対策1・2は効いた**:
- `^GSPC` は問題なく取得できた（失敗行なし）
- 相場環境が正常に戻った → `{'BULLISH': 1405, 'BEARISH': 757, 'NEUTRAL': 272, 'PANIC': 28}`
- 合算 **1,801件 / 52.6% / PF1.54 / 最大DD−27.5%** — 壊れる前（1,820 / 52.4% / 1.54）と同じ系列

**しかし公開が止まった**:

```
::error::公開数字の検証に失敗したので書き出しません（前回のJSONを残します）
  - トレード数が 1038 → 1801（73.5% 変化）。許容は ±10%
```

前回**公開されている値が壊れた 1,038** なので、そこから正しい 1,801 に戻す動きも「大きすぎる変化」として止まる。検査としては正しい挙動だが、**復旧できない**。

## 変更

手動実行（`workflow_dispatch`）に `allow_drift` を足した。

- 既定は `false` → 定時実行では今までどおり検査が効く
- 復旧のときだけ `true` を選ぶと `--allow-drift` が付く

```yaml
allow_drift:
  description: '前回公開値との乖離検査を通す（壊れた値から復旧するときだけ true）'
  type: boolean
  default: false
```

## この後

マージ後に `allow_drift=true` で1回流すと、`portfolio_stats.json` と Supabase が正しい値に戻る。
そのあとの定時実行は `false` に戻るので、検査は効いたまま。

⚠️ **`backtest_cache` も温め直しが要る。** 前回の温め（61分・1,260件）は壊れた相場環境で計算されているため。Publish が失敗して温めが skip されたので、いまキャッシュは壊れたままになっている。復旧実行が Publish を通れば、そのあとの温めで上書きされる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
