### PR TITLE
perf(precompute): 規定値3本を温め、キャッシュの有効性をデータの日付で決める（/rules 初回20秒→100ms）

### DIFF
--- a/precompute/tests/verify_cache_key.py
+++ b/precompute/tests/verify_cache_key.py
@@ -18,6 +18,7 @@ import sys
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import cache_key  # noqa: E402
+from warm_cache import PRESET_RULES_WARM  # noqa: E402
 
 APP_DIR = r"D:\マイドキュメント\Claude\Projects\ruletrade-app"
 DATA_THROUGH = "2026-09-04"
@@ -69,6 +70,36 @@ CASES = [
         dict(conditions=[{"column": "dev_25", "op": "lte", "value": -18}],
              hold_days=2, stop_pct=-5, cost_pct=0,
              regimes=["BULLISH", "NEUTRAL", "BEARISH", "PANIC"]),
+    ),
+    (
+        "規定値: BNF逆張り（warm_cache が温める形）",
+        {"conditions": PRESET_RULES_WARM[0]["conditions"],
+         "exit": {"stop_pct": -5, "ma_revert": 25, "calendar_days": 14, "cost_pct": 0},
+         "preset": True, "max_positions": None,
+         "regime_filter": PRESET_RULES_WARM[0]["regimes"]},
+        dict(conditions=PRESET_RULES_WARM[0]["conditions"],
+             calendar_days=14, stop_pct=-5, ma_revert=25, cost_pct=0,
+             regimes=PRESET_RULES_WARM[0]["regimes"]),
+    ),
+    (
+        "規定値: モメンタム（warm_cache が温める形）",
+        {"conditions": PRESET_RULES_WARM[1]["conditions"],
+         "exit": {"stop_pct": -5, "take_pct": 10, "calendar_days": 10, "cost_pct": 0},
+         "preset": True, "max_positions": None,
+         "regime_filter": PRESET_RULES_WARM[1]["regimes"]},
+        dict(conditions=PRESET_RULES_WARM[1]["conditions"],
+             calendar_days=10, stop_pct=-5, take_pct=10, cost_pct=0,
+             regimes=PRESET_RULES_WARM[1]["regimes"]),
+    ),
+    (
+        "規定値: ミネルヴィニ（warm_cache が温める形）",
+        {"conditions": PRESET_RULES_WARM[2]["conditions"],
+         "exit": {"stop_pct": -9, "calendar_days": 90, "cost_pct": 0},
+         "preset": True, "max_positions": None,
+         "regime_filter": PRESET_RULES_WARM[2]["regimes"]},
+        dict(conditions=PRESET_RULES_WARM[2]["conditions"],
+             calendar_days=90, stop_pct=-9, cost_pct=0,
+             regimes=PRESET_RULES_WARM[2]["regimes"]),
     ),
     (
         "書籍照合モード（内部専用）",

--- a/precompute/warm_cache.py
+++ b/precompute/warm_cache.py
@@ -76,16 +76,68 @@ def entry_sets():
                     }
 
 
+# ─────────────────────────────────────────────────────────
+# 規定値ルール3本（/rules を開いたときに最初に出る成績）
+#
+# ★ここは調整域とは別の族★
+# 調整域は「閾値×MA×出来高×保有日数」の格子だが、規定値は本番 v2.8.0 の
+# 条件そのもの（セクター別閾値・暦日の保有・25日線への戻りなど）で、
+# 格子の中に入っていない。温めておかないと、毎日その日の最初に開いた人が
+# 20秒待つことになる（2026-09-08 に実測）。
+#
+# ★ruletrade-app/src/content/rules-library.ts の requestForRule() と
+#   1つでも違うと、ハッシュがズレて当たらない。**変えるときは両方直す。**
+#   ズレても壊れず「速くならないだけ」なので気づきにくい。
+#   tests/verify_cache_key.py で照合すること。
+PRESET_RULES_WARM = [
+    {
+        "id": "bnf-reversal",
+        "conditions": [
+            {"column": "dev_25", "op": "lte", "threshold_mode": "sector_table"},
+            {"column": "vol_ratio_20", "op": "gte", "value": 1.1},
+            {"column": "bb_pos_1_5", "op": "lte", "value": 100},
+            {"column": "knife_guard", "op": "is_true"},
+        ],
+        "exit": {"stop_pct": -5, "ma_revert": 25, "calendar_days": 14},
+        "regimes": ["PANIC", "BEARISH", "NEUTRAL"],
+    },
+    {
+        "id": "momentum-breakout",
+        "conditions": [
+            {"column": "high_20_ratio", "op": "gte", "value": 100},
+            {"column": "vol_ratio_20", "op": "gte", "value": 1.5},
+            {"column": "dev_200", "op": "gte", "value": 0},
+            {"column": "dev_50", "op": "gte", "value": 0},
+            {"column": "high_52w_ratio", "op": "gte", "value": 95},
+            {"column": "ret_5d", "op": "lte", "value": 12},
+            {"column": "day_change", "op": "lte", "value": 8},
+        ],
+        "exit": {"stop_pct": -5, "take_pct": 10, "calendar_days": 10},
+        "regimes": ["BULLISH"],
+    },
+    {
+        "id": "minervini-template",
+        "conditions": [{"column": "minervini_entry", "op": "is_true"}],
+        "exit": {"stop_pct": -9, "calendar_days": 90},
+        "regimes": ["BULLISH", "NEUTRAL"],
+    },
+]
+
+
 class RpcTimeout(RuntimeError):
     pass
 
 
-def call_rpc(url, key, conds, regimes, hold_days, date_to, retries=2):
+def call_rpc(url, key, conds, regimes, hold_days, date_to, retries=2,
+             stop_pct=None, take_pct=None, calendar_days=None, ma_revert=None):
+    """出口の指定は既定で調整域のもの。規定値ルールを温めるときだけ上書きする。"""
     body = {
         "p_conditions": conds, "p_from": DATE_FROM, "p_to": date_to,
-        "p_hold_days": hold_days, "p_stop_pct": STOP_PCT, "p_take_pct": None,
+        "p_hold_days": hold_days,
+        "p_stop_pct": STOP_PCT if stop_pct is None else stop_pct,
+        "p_take_pct": take_pct,
         "p_regimes": regimes, "p_universe": UNIVERSE, "p_tickers": None,
-        "p_calendar_days": None, "p_ma_revert": None,
+        "p_calendar_days": calendar_days, "p_ma_revert": ma_revert,
         "p_entry_at": "close", "p_exit_style": "close",
     }
     for attempt in range(retries + 1):
@@ -191,6 +243,83 @@ def build_payload(trades, date_from, date_to):
     }
 
 
+def purge_stale_cache(url, key, date_to, dry_run=False):
+    """データの最終日が変わった古いエントリを消す（2026-09-09 Fable 相談⑦）。
+
+    キャッシュの有効性は「時計」ではなく「データの日付」で決める。
+    正規化したパラメータの `to` が daily_metrics の最終日なので、
+    日付が進めばキーが変わって前日の行には当たらなくなる。
+    ただし**残り続けると容量を食う**ので、ここで掃除する。
+
+    月次の全期間再計算のように「日付は同じだが中身が変わる」場合は、
+    このあとの温め直しが同じキーを上書きするので整合が取れる。
+    """
+    if dry_run:
+        log("  （--dry-run のため掃除しません）")
+        return 0
+    # PostgREST の JSON 演算子で「to が今日の最終日でない行」を消す
+    endpoint = "%s/rest/v1/backtest_cache?params->>to=neq.%s" % (url, date_to)
+    req = urllib.request.Request(
+        endpoint, method="DELETE",
+        headers={"apikey": key, "Authorization": "Bearer " + key,
+                 "Prefer": "return=representation", "Content-Type": "application/json"})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as r:
+            deleted = json.loads(r.read() or b"[]")
+        return len(deleted)
+    except Exception as e:  # 掃除に失敗しても温めは続ける
+        log("  ★古いキャッシュの掃除に失敗（続行します）: %s" % str(e)[:120])
+        return 0
+
+
+def warm_presets(url, key, date_to, dry_run=False):
+    """規定値3本を温める。/rules の初回表示がここで決まる。
+
+    戻り値: (保存した件数, 落ちたもののリスト)
+    """
+    rows = []
+    failed = []
+    for r in PRESET_RULES_WARM:
+        ex = r["exit"]
+        t1 = time.time()
+        try:
+            trades = call_rpc(
+                url, key, r["conditions"], r["regimes"], None, date_to,
+                stop_pct=ex.get("stop_pct"), take_pct=ex.get("take_pct"),
+                calendar_days=ex.get("calendar_days"), ma_revert=ex.get("ma_revert"))
+        except Exception as e:
+            failed.append((r["id"], str(e)[:120]))
+            log("  ★%s を温められませんでした: %s" % (r["id"], str(e)[:120]))
+            continue
+        trades = apply_no_overlap(trades)
+
+        # ★0件は保存しない★
+        # 2026-09-08、閾値表が読めず「エラーも出さず0件」が焼き付いた事故があった。
+        # 規定値が0件になることは本来ありえないので、異常として扱う。
+        if not trades:
+            failed.append((r["id"], "0件が返った（入力データを疑う）"))
+            log("  ★%s が0件でした。保存しません" % r["id"])
+            continue
+
+        p_ = cache_key.normalize(
+            conditions=r["conditions"], hold_days=None,
+            calendar_days=ex.get("calendar_days"), ma_revert=ex.get("ma_revert"),
+            stop_pct=ex.get("stop_pct"), take_pct=ex.get("take_pct"),
+            cost_pct=COST_PCT, regimes=r["regimes"],
+            date_from=DATE_FROM, date_to=date_to, universe=UNIVERSE)
+        rows.append({
+            "params_hash": cache_key.params_hash(p_),
+            "params": p_,
+            "result": build_payload(trades, DATE_FROM, date_to),
+            "computed_at": dt.datetime.now(dt.timezone.utc).isoformat(),
+        })
+        log("  %s: %d件 / %.1f秒" % (r["id"], len(trades), time.time() - t1))
+
+    if rows and not dry_run:
+        supabase_io.upsert("backtest_cache", rows, "params_hash", log=lambda *_: None)
+    return len(rows), failed
+
+
 def parse_args():
     p = argparse.ArgumentParser(description="規定値の調整域をキャッシュに温める")
     p.add_argument("--env-file", default="")
@@ -207,6 +336,19 @@ def main():
     t0 = time.time()
 
     date_to = supabase_io.max_value("daily_metrics", "date")
+
+    # ★規定値3本を先に温める★
+    # 調整域（1,260通り・約60〜80分）より先に済ませる。ここが冷えていると
+    # /rules を開いた最初の人が20秒待つので、優先度が高い。
+    # 古い日付のエントリを先に掃除する（キーが変わって当たらなくなった行）
+    log("古いキャッシュを掃除します（データ最終日 %s 以外）" % date_to)
+    purged = purge_stale_cache(url, key, date_to, args.dry_run)
+    log("  %d 件削除" % purged)
+
+    log("規定値3本を温めます（/rules の初回表示）")
+    preset_saved, preset_failed = warm_presets(url, key, date_to, args.dry_run)
+    log("  規定値: 保存 %d 件 / 失敗 %d 件" % (preset_saved, len(preset_failed)))
+
     sets = list(entry_sets())
     if args.limit:
         sets = sets[:args.limit]
@@ -258,8 +400,12 @@ def main():
         supabase_io.upsert("backtest_cache", rows, "params_hash", log=lambda *_: None)
         saved += len(rows)
 
-    log("保存 %d 件 / 見送り %d 件 / 所要 %.1f 分"
-        % (saved, len(skipped), (time.time() - t0) / 60))
+    log("保存 %d 件（うち規定値 %d 件）/ 見送り %d 件 / 所要 %.1f 分"
+        % (saved + preset_saved, preset_saved, len(skipped), (time.time() - t0) / 60))
+    if preset_failed:
+        log("★規定値を温められなかったものがあります（/rules の初回表示が遅くなります）:")
+        for rid, why in preset_failed:
+            log("    %s ― %s" % (rid, why))
     if skipped:
         log("★時間内に終わらず見送った組み合わせ（会員が選ぶとライブ計算になる）:")
         for k in skipped[:20]:


### PR DESCRIPTION
2026-09-09 Fable 相談⑦。`/rules` の初回表示が20秒かかっていた対策。

## 1. 規定値3本を warm_cache に追加

夜間バッチが温めていた1,260件は「閾値×MA×出来高×保有日数」の格子で、**規定値そのもの**（`threshold_mode: sector_table`・暦日の保有・25日線への戻り）は**その中に入っていなかった**。だから `/rules` を開くたびに BNF で約20秒のライブ計算が走っていた。

`PRESET_RULES_WARM` を足し、**調整域より先に**温める（初回表示に直結するため優先）。

```
bnf-reversal:       1,914件 / 19.2秒
momentum-breakout:  5,378件 / 11.6秒
minervini-template: 1,060件 /  6.1秒
保存 3 件 / 失敗 0 件 / 37.7 秒
```

`call_rpc` は出口の指定を受け取れるよう汎用化した（既定値は今までどおりなので調整域の挙動は変わらない）。

**0件は保存しない。** 2026-09-08 に閾値表が読めず「エラーも出さず0件」が焼き付いた事故があったため。規定値が0件になることはありえないので異常として扱う。

## 2. ハッシュの一致を機械で確認

`tests/verify_cache_key.py` に規定値3本のケースを追加。**Python と TypeScript で `params_hash` が一致**することを確認した（9件すべて合格）。ズレても壊れず「速くならないだけ」なので、必ずここで見る。

アプリ側から実際に命中することも確認した。

```
BNF逆張り:     命中 805ms / trades=1914
モメンタム:     命中 248ms / trades=5378
ミネルヴィニ:   命中  92ms / trades=1060
```

## 3. キャッシュの有効性を「時計」から「データの日付」へ

20時間の期限は、**データが1日も進んでいないのに期限切れで作り直す**ため、夜間バッチの直後でなければ毎日1回20秒待たされる原因になっていた。

期限を持たない方式に変更。正規化パラメータの `to` が `daily_metrics` の最終日なので、**日次更新で日付が進めばキーが変わり、前日の行には当たらない**（＝自動で無効化）。温め直しは夜間バッチが埋める。

古い `to` の行は `purge_stale_cache` が消す。実測で **3,792 → 1,263件**（当日ぶん1,260＋規定値3本が残る）。月次の全期間再計算のように「日付は同じで中身が変わる」場合は、同じキーを上書きするので整合が取れる。

## 効果

| | 変更前 | 変更後 |
|---|---|---|
| `/rules` の初回表示 | 約20秒 | **100ms 前後**（温め済みに命中） |
| キャッシュの無効化 | 20時間の時計 | データの日付が進んだとき |
| 溜まり続ける古い行 | 放置 | 夜間バッチが掃除 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
