### PR TITLE
🛡️ 更新が止まったことに気づける仕組み（stale フラグ・予備 cron・翌朝の締めチェック）

### DIFF
--- a/.github/workflows/daily-signal.yml
+++ b/.github/workflows/daily-signal.yml
@@ -10,6 +10,7 @@ on:
     - cron: '0 23 * * 0-4'   # 朝 08:00 JST(月〜金)
     - cron: '0 3 * * 1-5'    # 昼 12:00 JST(月〜金)
     - cron: '0 9 * * 1-5'    # 夕 18:00 JST(月〜金)
+    - cron: '30 10 * * 1-5'  # 予備: 夕方の本命(18:00 JST)の90分後(JST 19:30)。夕の回が起動しなかった日の保険
   workflow_dispatch:          # 手動実行も可能
     inputs:
       capital:
@@ -46,7 +47,41 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # ★予備実行の冪等ガード（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」）
+      #   本命 cron は起動しないことがある（2026-09-05 に実際に起きた）。
+      #   その保険として予備 cron を置いているが、本命が動いた日に二重で走らせる
+      #   必要はない。**当日ぶんが既にあるならここで打ち切る**。
+      #   手動実行（workflow_dispatch）は意図的な再実行なのでスキップしない。
+      - name: Skip if already fresh (予備実行のみ)
+        id: guard
+        run: |
+          # ★このワークフローは朝(8:00)・昼(12:00)・夕(18:00)の1日3回動くのが正常。
+          #   鮮度で判定してよいのは**予備の回だけ**。朝や昼の回でスキップすると
+          #   本来の3回運用が壊れる（当日ぶんは朝の時点で既にあるため）。
+          #   予備は JST 19:30 = UTC 10:30 に置いてあるので、その回だけ見る。
+          HOUR_UTC=$(date -u +%H); MIN_UTC=$(date -u +%M)
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "手動実行なのでスキップ判定をしません"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # 予備の回（UTC 10:30 前後）以外は必ず実行する。
+          # schedule は数時間遅れることがあるので、幅を持たせて 10〜13時台を予備とみなす
+          if [ "$HOUR_UTC" -lt 10 ] || [ "$HOUR_UTC" -gt 13 ]; then
+            echo "本命の回（朝/昼/夕）なので必ず実行します（UTC ${HOUR_UTC}:${MIN_UTC}）"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if python check_freshness.py --target signals_log; then
+            echo "当日ぶんは取得済み。以降のステップを飛ばします"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "未取得または古いので実行します"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Determine time slot (朝/昼/夕)
+        if: steps.guard.outputs.skip != 'true'
         id: slot
         run: |
           JST_HOUR=$(TZ='Asia/Tokyo' date +%H)
@@ -66,6 +101,7 @@ jobs:
       # ★2026-07-22: v2.7系→v2.8.0へ差し替え(341銘柄・サンバイオ除外・ナイフガード・
       #   セクター別リスク調整)。CLIは完全互換。ザラ場通知/朝ダイジェストと同一ロジックに統一。
       - name: Run Daily Scanner v2.8.1(新高値型フィルタ)
+        if: steps.guard.outputs.skip != 'true'
         env:
           CAPITAL: ${{ github.event.inputs.capital || '1000000' }}
           RISK:    ${{ github.event.inputs.risk || '1.0' }}
@@ -77,6 +113,7 @@ jobs:
             --json-output signal.json
 
       - name: Add timestamp header
+        if: steps.guard.outputs.skip != 'true'
         run: |
           cat > signal_final.md <<HEADER
           > ⏰ 自動実行: ${{ steps.slot.outputs.time_jst }} JST (${{ steps.slot.outputs.slot }})
@@ -86,6 +123,7 @@ jobs:
           cat signal.md >> signal_final.md
 
       - name: Create or update today's signal issue
+        if: steps.guard.outputs.skip != 'true'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "📊 シグナル ${{ steps.slot.outputs.date_jst }} ${{ steps.slot.outputs.slot }}"
@@ -95,6 +133,7 @@ jobs:
             ${{ steps.slot.outputs.slot_en }}
 
       - name: Upload signal artifacts
+        if: steps.guard.outputs.skip != 'true'
         uses: actions/upload-artifact@v4
         with:
           name: signal-${{ steps.slot.outputs.date_jst }}-${{ steps.slot.outputs.slot_en }}
@@ -105,12 +144,14 @@ jobs:
 
       # ★新機能: シグナル履歴を signals_log.csv に追記
       - name: Append to signals_log.csv
+        if: steps.guard.outputs.skip != 'true'
         run: |
           python signal_logger.py signal.json signals_log.csv
 
       # ★2026-07-22: lost-update対策(realtime-signal.ymlと同方式)。
       #   旧実装は他コミットと衝突するとpush失敗でシグナル行が消失(7/13の教訓)。
       - name: Commit signals_log.csv (行を失わないマージ+リトライ)
+        if: steps.guard.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -143,6 +184,7 @@ jobs:
           exit 1
 
       - name: Write summary
+        if: steps.guard.outputs.skip != 'true'
         run: |
           echo "## 📊 デイリースキャナー v2.8.0 実行完了" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/data-healthcheck.yml
+++ b/.github/workflows/data-healthcheck.yml
@@ -8,7 +8,12 @@ name: Data Healthcheck (kaburadar.jp)
 # 傾斜計・着火が「まだ走っていないだけ」で誤検知した。
 on:
   schedule:
-    - cron: '43 14 * * *'
+    - cron: '43 14 * * *'          # 23:43 JST: その日の全ジョブ終了後にIssueで通知
+    # ★翌朝 7:00 JST (= 前日 22:00 UTC) の締めチェック（指示書 §14-2 / Fable 2026-09-09）
+    #   予備 cron でも埋まらなかった場合に、**ジョブを失敗させて**気づけるようにする。
+    #   23:43 の回は Issue を立てるだけで success のままなので、
+    #   Actions の一覧を見ても異常が分からなかった（2026-09-05 の欠落が4日間放置された）。
+    - cron: '0 22 * * 0-4'         # 朝 07:00 JST(月〜金)
   workflow_dispatch:
 
 permissions:
@@ -17,6 +22,9 @@ permissions:
 
 jobs:
   check:
+    # 23:43 の回だけ。朝7:00の回でここを動かすと、tol=0（当日更新必須）の判定が
+    # 「前日の夜に更新済み＝1営業日前」を古いとみなして誤ってIssueを立てる。
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '43 14 * * *'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -108,3 +116,42 @@ jobs:
           title: "⚠️ 株レーダー: データ更新が止まっています"
           content-filepath: report.md
           labels: data-alert
+
+
+  # ─────────────────────────────────────────────
+  #  翌朝の締めチェック（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」）
+  #
+  #  上の check ジョブは Issue を立てるだけで、ジョブ自体は success になる。
+  #  そのため Actions の一覧を眺めても異常に気づけず、2026-09-05 に
+  #  free-scanner が起動しなかったことが4日間放置された。
+  #
+  #  こちらは **前営業日ぶんが無ければジョブを失敗させる**。
+  #  本命 cron → 予備 cron でも埋まらなかった、という最後の砦。
+  # ─────────────────────────────────────────────
+  morning-gate:
+    # 朝7:00の回だけ動かす（23:43 の回は上の check だけでよい）
+    if: github.event_name == 'workflow_dispatch' || github.event.schedule == '0 22 * * 0-4'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: 前営業日ぶんが揃っているか
+        run: |
+          fail=0
+          for t in free_scanner market_jiai radar portfolio_stats signals_log; do
+            if python check_freshness.py --target "$t"; then
+              echo "  OK"
+            else
+              echo "::error::$t が前営業日ぶんまで更新されていません（本命・予備とも取りこぼした可能性）"
+              fail=1
+            fi
+            echo "---"
+          done
+          exit $fail

--- a/.github/workflows/free-scanner.yml
+++ b/.github/workflows/free-scanner.yml
@@ -5,6 +5,7 @@ name: Free Scanner (無料版BNFスキャナー)
 on:
   schedule:
     - cron: '30 10 * * 1-5'
+    - cron: '30 11 * * 1-5'  # 予備: 本命の60分後(JST 20:30)。本命が起動しなかった日の保険
   workflow_dispatch:
 
 permissions:
@@ -30,11 +31,34 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # ★予備実行の冪等ガード（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」）
+      #   本命 cron は起動しないことがある（2026-09-05 に実際に起きた）。
+      #   その保険として予備 cron を置いているが、本命が動いた日に二重で走らせる
+      #   必要はない。**当日ぶんが既にあるならここで打ち切る**。
+      #   手動実行（workflow_dispatch）は意図的な再実行なのでスキップしない。
+      - name: Skip if already fresh (予備実行のみ)
+        id: guard
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "手動実行なのでスキップ判定をしません"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if python check_freshness.py --target free_scanner; then
+            echo "当日ぶんは取得済み。以降のステップを飛ばします"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "未取得または古いので実行します"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Run free scanner
+        if: steps.guard.outputs.skip != 'true'
         run: |
           python scanner_free.py --output docs/free_scanner.json
 
       - name: Commit free_scanner.json
+        if: steps.guard.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -49,6 +73,7 @@ jobs:
           fi
 
       - name: Write summary
+        if: steps.guard.outputs.skip != 'true'
         run: |
           echo "## 無料版スキャナー実行完了" >> $GITHUB_STEP_SUMMARY
           python - >> $GITHUB_STEP_SUMMARY <<'PY'

--- a/.github/workflows/precompute-daily.yml
+++ b/.github/workflows/precompute-daily.yml
@@ -11,6 +11,7 @@ name: Precompute Metrics (日次差分)
 on:
   schedule:
     - cron: '30 9 * * 1-5'    # 夕 18:30 JST(月〜金)
+    - cron: '30 10 * * 1-5'  # 予備: 本命の60分後(JST 19:30)。本命が起動しなかった日の保険
   workflow_dispatch:
     inputs:
       days:
@@ -50,7 +51,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      # ★予備実行の冪等ガード（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」）
+      #   本命 cron は起動しないことがある（2026-09-05 に実際に起きた）。
+      #   その保険として予備 cron を置いているが、本命が動いた日に二重で走らせる
+      #   必要はない。**当日ぶんが既にあるならここで打ち切る**。
+      #   手動実行（workflow_dispatch）は意図的な再実行なのでスキップしない。
+      - name: Skip if already fresh (予備実行のみ)
+        id: guard
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "手動実行なのでスキップ判定をしません"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if python check_freshness.py --target portfolio_stats; then
+            echo "当日ぶんは取得済み。以降のステップを飛ばします"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "未取得または古いので実行します"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Update daily_metrics / market_condition
+        if: steps.guard.outputs.skip != 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -65,6 +88,7 @@ jobs:
       # 規定値ポートフォリオの成績（＝サイトの公開数字と同じ計算）を作り直す。
       # 分割利確・サーキットブレーカー・同セクター上限を含むので Python が正本。
       - name: Rebuild preset portfolio result
+        if: steps.guard.outputs.skip != 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -93,6 +117,7 @@ jobs:
       # 静的サイト（ruletrade.jp）と会員アプリ /dashboard がこの同じ値を見る
       # ＝「一つの定義・一つの数字」（引継ぎ.md §19・起動文 2-4c）。
       - name: Publish portfolio_stats.json
+        if: steps.guard.outputs.skip != 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
@@ -123,6 +148,7 @@ jobs:
       # 調整域のキャッシュ温め（最後に回す。ここが落ちても公開数字は出ている）
       # スライダーの体感を良くするためのもので、正しさには関わらない。
       - name: Warm preset adjustment cache
+        if: steps.guard.outputs.skip != 'true'
         env:
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}

--- a/.github/workflows/radar-publish.yml
+++ b/.github/workflows/radar-publish.yml
@@ -10,10 +10,21 @@ name: Radar Publish (kaburadar.jp)
 #   → daily-signal.yml には一切触らず、その完了を待って
 #     artifact の signal.json から radar.json を作る独立フローにする。
 #     これで daily-signal.yml が今後何度上書きされても地合いは止まらない。
+#
+# ■ 予備 cron について（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」）
+#   このワークフローは daily-signal の完了で起動するので、
+#   daily-signal 自体が起動しなかった日は radar.json も出ない。
+#   他の3本と同じ「本命の60〜90分後に予備 cron」を、
+#   **daily-signal には触らないまま**入れるために、schedule を足して
+#   下の「Resolve source run id」の手動実行用の分岐
+#   （最後に成功した daily-signal を探す）に相乗りさせる。
+#   当日ぶんが既に出ていれば、下の冪等ガードで何もせず終わる。
 on:
   workflow_run:
     workflows: ["Daily Trading Signal (v2.8.1)"]
     types: [completed]
+  schedule:
+    - cron: '0 11 * * 1-5'   # 予備: JST 20:00（本命の公開 JST 18:20 前後の約100分後）
   workflow_dispatch:
 
 permissions:
@@ -29,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     # スキャナーが失敗した回は signal.json が信頼できないのでスキップ
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout repository
@@ -40,8 +51,28 @@ jobs:
         with:
           python-version: '3.11'
 
+      # ★予備実行の冪等ガード（他3本と同じ考え方）
+      #   本命（daily-signal の完了）で既に当日ぶんが出ているなら何もしない。
+      #   手動実行は意図的な再実行なのでスキップしない。
+      - name: Skip if already fresh (予備実行のみ)
+        id: guard
+        run: |
+          if [ "${{ github.event_name }}" != "schedule" ]; then
+            echo "予備 cron 以外なのでスキップ判定をしません"
+            echo "skip=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if python check_freshness.py --target radar; then
+            echo "当日ぶんは公開済み。以降のステップを飛ばします"
+            echo "skip=true" >> $GITHUB_OUTPUT
+          else
+            echo "未公開または古いので実行します"
+            echo "skip=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Resolve source run id
         id: src
+        if: steps.guard.outputs.skip != 'true'
         run: |
           if [ -n "${{ github.event.workflow_run.id }}" ]; then
             echo "id=${{ github.event.workflow_run.id }}" >> $GITHUB_OUTPUT
@@ -54,6 +85,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Download signal.json artifact
+        if: steps.guard.outputs.skip != 'true'
         run: |
           gh run download "${{ steps.src.outputs.id }}" -D artifacts
           SIG=$(find artifacts -name signal.json | head -1)
@@ -67,6 +99,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish radar.json (競合時はリベースして再試行)
+        if: steps.guard.outputs.skip != 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/check_freshness.py
+++ b/check_freshness.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""公開JSONの鮮度を1か所で判定する。
+
+■ 何のためか（指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」・Fable）
+GitHub Actions の schedule は**起動しないことがある**。2026-09-05(金)は
+free-scanner が丸ごと起動せず、9/7ぶんも5時間半遅れて 9/8 00:59 に走ったため、
+公開JSONの対象日が4日間そのまま残った。失敗記録が出ないので気づけない。
+
+対策は2つで、どちらもこのスクリプトを使う。
+  (b) 本命 cron の60〜90分後に予備 cron を置き、
+      **当日ぶんが既にあるならスキップ**する（冪等ガード）
+  (c) 翌朝 7:00 JST の健全性チェックで、前営業日ぶんが無ければ**失敗**させる
+
+■ 使い方
+    python check_freshness.py --target free_scanner            # 鮮度を表示するだけ
+    python check_freshness.py --target free_scanner --quiet    # 終了コードだけ
+      終了コード 0 = 最新（予備実行は要らない）
+      終了コード 1 = 古い（予備実行すべき／健全性チェックなら失敗）
+
+    # ワークフローからはこう使う（新鮮ならステップを飛ばす）
+    if python check_freshness.py --target free_scanner --quiet; then
+      echo "当日ぶんは取得済み。スキップします"; exit 0
+    fi
+
+■ 「新鮮」の定義
+`asof`（そのJSONが見ている最新営業日）が **前営業日以上**なら新鮮。
+当日の終値が固まるのは 15:00 JST 以降なので、それより前・土日は前営業日までしか
+確定していない。**祝日は考慮していない**（土日だけ飛ばす）ため、祝日明けは
+「古い」と出ることがある。黙って古いデータを配るよりは安全側なので、この粗さで運用する。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+JST = timezone(timedelta(hours=9))
+
+# 対象ごとに「どのファイルの・どのキーを見るか」。
+# キーは上から順に探し、最初に見つかったものを asof として使う。
+TARGETS = {
+    "free_scanner": {
+        "path": "docs/free_scanner.json",
+        # asof は 2026-09-09 に足したキー。それ以前に生成された JSON には無いので
+        # target_date（仕様として1営業日遅れる）で代用する。その場合は
+        # default_lag=1 のぶん甘く見ないと、正常なのに「古い」と出てしまう。
+        "keys": ["asof", "target_date"],
+        "lag_when_key": {"target_date": 1},
+        "label": "無料版スキャナー",
+    },
+    "market_jiai": {
+        "path": "docs/market_jiai.json",
+        # market_jiai は遅延なし（最新終値で判定）なので target_date でも遅れ0
+        "keys": ["asof", "target_date"],
+        "label": "地合い専用JSON",
+    },
+    "radar": {
+        "path": "docs/radar.json",
+        # radar.json は日付キーを持たず updated（生成時刻）しかない
+        "keys": ["asof", "target_date", "updated"],
+        "label": "株レーダー地合い",
+    },
+    "portfolio_stats": {
+        "path": "docs/portfolio_stats.json",
+        "keys": ["asof"],
+        "label": "公開数字",
+    },
+    "signals_log": {
+        # 日次シグナルは CSV。最終行の scan_date を見る
+        "path": "signals_log.csv",
+        "csv_column": "scan_date",
+        "label": "日次シグナル",
+    },
+}
+
+
+def prev_business_day(d):
+    """土日を飛ばして1営業日戻る（祝日は考慮しない）。"""
+    d -= timedelta(days=1)
+    while d.weekday() >= 5:          # 土(5)・日(6)
+        d -= timedelta(days=1)
+    return d
+
+
+def latest_settled_business_day(now=None):
+    """いま時点で終値が確定しているはずの直近営業日。"""
+    now = now or datetime.now(JST)
+    d = now.date()
+    if now.hour < 15 or d.weekday() >= 5:
+        d = prev_business_day(d)
+    return d
+
+
+def _date_of(value):
+    """'2026-09-08' でも '2026-09-08T23:42:45+09:00' でも日付にする。"""
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).astimezone(JST).date()
+    except ValueError:
+        try:
+            return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
+        except ValueError:
+            return None
+
+
+def read_asof(spec):
+    """対象の asof（見ている最新営業日）を返す。読めなければ None。"""
+    path = spec["path"]
+    if not os.path.exists(path):
+        return None, "ファイルがありません: %s" % path
+
+    if "csv_column" in spec:
+        import csv
+        last = None
+        with open(path, encoding="utf-8-sig", newline="") as f:
+            for row in csv.DictReader(f):
+                v = row.get(spec["csv_column"])
+                if v:
+                    last = v
+        return _date_of(last), None
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+    except (ValueError, OSError) as e:
+        return None, "読めません: %s" % e
+
+    for k in spec["keys"]:
+        if data.get(k):
+            # どのキーで代用したかによって、許容する遅れが変わる
+            lag = spec.get("lag_when_key", {}).get(k, 0)
+            return _date_of(data[k]), None if lag == 0 else "__lag__%d" % lag
+    return None, "日付のキーが見つかりません（探した: %s）" % ", ".join(spec["keys"])
+
+
+def main():
+    ap = argparse.ArgumentParser(description="公開JSONの鮮度を判定する")
+    ap.add_argument("--target", required=True, choices=sorted(TARGETS),
+                    help="どの出力を見るか")
+    ap.add_argument("--quiet", action="store_true", help="終了コードだけ返す")
+    ap.add_argument("--allow-lag-days", type=int, default=0,
+                    help="この営業日数までの遅れは新鮮とみなす（既定0）")
+    args = ap.parse_args()
+
+    spec = TARGETS[args.target]
+    asof, err = read_asof(spec)
+    expected = latest_settled_business_day()
+
+    # 代用キーを使ったぶんの遅れ（例: asof が無く target_date で見た場合の1営業日）
+    key_lag = 0
+    if err and err.startswith("__lag__"):
+        key_lag = int(err[len("__lag__"):])
+        err = None
+
+    limit = expected
+    for _ in range(max(args.allow_lag_days, 0) + key_lag):
+        limit = prev_business_day(limit)
+
+    fresh = asof is not None and asof >= limit
+    if not args.quiet:
+        print("対象      : %s (%s)" % (spec["label"], spec["path"]))
+        print("asof      : %s" % (asof or "取得できず"))
+        print("期待       : %s 以降" % limit)
+        print("判定       : %s" % ("最新" if fresh else "古い"))
+        if err:
+            print("メモ       : %s" % err)
+        if not fresh and asof:
+            print("※ 実行が飛んだか、大きく遅れています。")
+    return 0 if fresh else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scanner_free.py
+++ b/scanner_free.py
@@ -306,26 +306,28 @@ def scan(data: dict[str, pd.DataFrame], meta: pd.DataFrame,
         "nikkei_close": round(float(n225["Close"].iloc[-1]), 2),
     }
 
-    # ★target_date が古いことを機械で分かるようにする(指示書 §14-2・2026-09-09)★
+    # ★更新が止まっていることを機械で分かるようにする(指示書 §14-2・2026-09-09 Fable)★
     #
-    #   target_date は「取得できた日経の最新営業日から delay 営業日前」なので、
-    #   ロジックとしては常に正しい。古くなるのは**このスクリプトが走った時刻**の問題。
+    #   asof = このスキャンが見た「日経の最新営業日」。
+    #   stale = asof が前営業日より古い ＝ 実行が飛んだか、大きく遅れた。
+    #
+    #   target_date（乖離率上位3件の対象日）は仕様として1営業日遅れるので、
+    #   これを鮮度の判定に使うと「仕様どおりの遅れ」と「更新停止」が混ざる。
+    #   asof で見れば、遅れているのは実行そのものだと一意に分かる。
     #
     #   実例(2026-09-05〜09-08):
-    #     ・9/5(金)のスケジュール実行が GitHub Actions 側で**起動しなかった**
-    #     ・9/7ぶんの実行が5時間半遅れて 9/8 00:59 JST に起動した
-    #     ・その時点で取れる日経の最新終値は 9/4(金)だったので target_date=09-03
-    #   結果、9/4 の生成分と同じ 09-03 が 4日間そのまま残った。
+    #     ・9/5(金)のスケジュール実行が GitHub Actions 側で起動しなかった
+    #     ・9/7ぶんが5時間半遅れて 9/8 00:59 JST に起動した
+    #     ・その時点で取れる日経の最新終値は 9/4 だったので asof=09-04・target=09-03
+    #   このとき前営業日は 9/5 なので asof < 前営業日 → stale=true になる。
     #
-    #   サイト側は「1営業日遅れの仕様」と「更新が止まっている」を区別できないので、
-    #   **実行時点で本来あるべき対象日**と比べた遅れを出す。
-    expected = _expected_target_date(delay)
-    lag = _business_days_between(data_date.date(), expected)
-    result["target_date_expected"] = expected.strftime("%Y-%m-%d")
-    result["target_date_lag_days"] = lag
-    result["target_date_stale"] = bool(lag > 0)
-    for k in ("target_date_expected", "target_date_lag_days", "target_date_stale"):
-        jiai_live[k] = result[k]
+    #   祝日は考慮していない（土日だけ飛ばす）ので、祝日明けは stale=true が
+    #   出ることがある。黙って古い日付を出すよりは安全側なので、この粗さで運用する。
+    asof = live_date.date()
+    prev_bd = _prev_business_day_from_now()
+    for d in (result, jiai_live):
+        d["asof"] = asof.strftime("%Y-%m-%d")
+        d["stale"] = bool(asof < prev_bd)
 
     return result, jiai_live
 
@@ -335,6 +337,19 @@ def _prev_business_day(d):
     d -= timedelta(days=1)
     while d.weekday() >= 5:          # 土(5)・日(6)
         d -= timedelta(days=1)
+    return d
+
+
+def _prev_business_day_from_now():
+    """実行時点で「終値が確定しているはずの直近営業日」。
+
+    当日の終値が固まるのは 15:00 JST 以降。それより前、または土日に走った
+    場合は、前営業日までしか確定していない。
+    """
+    now = datetime.now(JST)
+    d = now.date()
+    if now.hour < 15 or d.weekday() >= 5:
+        d = _prev_business_day(d)
     return d
 
 


### PR DESCRIPTION
## なぜ

2026-09-05(金)に free-scanner の schedule が**起動せず**、9/7ぶんも5時間半遅れて 9/8 00:59 に走ったため、公開JSONの対象日が **4日間 09-03 のまま**残りました。GitHub Actions は「起動しなかった」を失敗として記録しないので、誰も気づけませんでした。

指示書 §14-2 / 引継ぎ.md §19「発見 2026-09-09」の Fable の判断にしたがい、対策を3層で入れます。

## 何を入れたか

### 1層目 — 出力に印を付ける（`scanner_free.py`）

`asof`（見ている最新営業日）と `stale`（asof が前営業日より古ければ true）を `free_scanner.json` / `market_jiai.json` に出します。サイト側が古いデータを**そうと分かる形で**扱えます。
以前の `target_date_expected` / `target_date_lag_days` / `target_date_stale` は asof 基準に一本化して置き換えました。

### 2層目 — 予備 cron ＋ 冪等ガード

本命の60〜90分後に予備を1本。本命が動いた日は `check_freshness.py`（新規）で当日ぶんの有無を見て**何もせず終わります**。

| ワークフロー | 本命 | 予備 | 鮮度の見どころ |
|---|---|---|---|
| free-scanner | JST 19:30 | **JST 20:30** | `docs/free_scanner.json` |
| precompute-daily | JST 18:30 | **JST 19:30** | `docs/portfolio_stats.json` |
| daily-signal | JST 8:00 / 12:00 / 18:00 | **JST 19:30** | `signals_log.csv` |
| radar-publish | daily-signal の完了 | **JST 20:00** | `docs/radar.json` |

- **daily-signal** は朝/昼/夕の3回運用なので、鮮度で打ち切るのは**予備の回（UTC 10〜13時台）だけ**に限定しました。朝の回が昼・夕をスキップさせないためです。
- **radar-publish** だけは `workflow_run` 起動です。`daily-signal.yml` には一切触らない設計意図（2026-08-13 に上書きされて地合いが4日止まった経緯）を保つため、`schedule` を足して既存の「最後に成功した run を探す」分岐に相乗りさせました。

### 3層目 — 翌朝の締めチェック（`data-healthcheck.yml` の `morning-gate`）

予備でも埋まらなかった場合の最後の砦。**JST 翌朝7:00 に前営業日ぶんが無ければジョブを失敗させます。**

既存の `check` ジョブは Issue を立てるだけで success のままなので、Actions の一覧を見ても異常が分かりませんでした。そちらは 23:43 の回に限定しています（朝7:00 で動かすと `tol=0`（当日更新必須）の判定が前夜の更新を「古い」と誤検知するため）。

**監視対象に `free_scanner.json` と `portfolio_stats.json` が入っていなかった**のも今回見逃された一因なので、5対象すべてを見ます。

## 確かめたこと

- **stale フラグ 6ケース** — 事故の 9/8 00:59 が `true`、正常時・土日は `false`
- **締めチェックを2時点で** —
  - 今朝 9/9 07:00 → 5対象すべて OK（誤検知しない）
  - 事故当日 9/8 07:00（free_scanner が 09-03 で停止）→ **free_scanner のみ NG**、ジョブが失敗する
- 5本すべて YAML として妥当・既存の `if: always()` 等は保持

## 見てほしいところ

- 予備 cron の時刻（本命の60〜90分後という指示の範囲内ですが、radar-publish だけ本命の公開時刻が読みにくいので約100分後にしています）
- 祝日は考慮していません（土日だけ飛ばす）。祝日明けに `morning-gate` が失敗する可能性がありますが、**黙って古いデータを配るより安全側**と判断しました

🤖 Generated with [Claude Code](https://claude.com/claude-code)
