### PR TITLE
🔕 daily-signal の予備実行では Issue を作らない

### DIFF
--- a/.github/workflows/daily-signal.yml
+++ b/.github/workflows/daily-signal.yml
@@ -63,6 +63,7 @@ jobs:
           if [ "${{ github.event_name }}" != "schedule" ]; then
             echo "手動実行なのでスキップ判定をしません"
             echo "skip=false" >> $GITHUB_OUTPUT
+            echo "is_backup=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           # 予備の回（UTC 10:30 前後）以外は必ず実行する。
@@ -70,8 +71,11 @@ jobs:
           if [ "$HOUR_UTC" -lt 10 ] || [ "$HOUR_UTC" -gt 13 ]; then
             echo "本命の回（朝/昼/夕）なので必ず実行します（UTC ${HOUR_UTC}:${MIN_UTC}）"
             echo "skip=false" >> $GITHUB_OUTPUT
+            echo "is_backup=false" >> $GITHUB_OUTPUT
             exit 0
           fi
+          # ここから先は予備の回。人に届くもの（Issue）は出さない。
+          echo "is_backup=true" >> $GITHUB_OUTPUT
           if python check_freshness.py --target signals_log; then
             echo "当日ぶんは取得済み。以降のステップを飛ばします"
             echo "skip=true" >> $GITHUB_OUTPUT
@@ -122,8 +126,16 @@ jobs:
           HEADER
           cat signal.md >> signal_final.md
 
+      # ★予備の回では作らない（Fable 2026-09-09）
+      #   このワークフローにメール送信・X投稿・realtime_notifier は無い
+      #   （それらは morning-digest.yml / realtime-signal.yml / ai-analysis.yml が
+      #     それぞれ独自の cron で持っている）。
+      #   daily-signal で人に届くのはこの Issue だけなので、ここを止める。
+      #   予備は本命が落ちた日にしか動かないので二重にはならないはずだが、
+      #   **二重通知は欠落より悪い**ので、はずれても害の無い側に倒す。
+      #   JSON・artifact・signals_log.csv は予備でも作る（データは欠かさない）。
       - name: Create or update today's signal issue
-        if: steps.guard.outputs.skip != 'true'
+        if: steps.guard.outputs.skip != 'true' && steps.guard.outputs.is_backup != 'true'
         uses: peter-evans/create-issue-from-file@v5
         with:
           title: "📊 シグナル ${{ steps.slot.outputs.date_jst }} ${{ steps.slot.outputs.slot }}"


### PR DESCRIPTION
[PR #375](https://github.com/oo12takemaru-create/stock-trading-/pull/375) の**取りこぼし分**です。予備 cron 本体は #375 でマージ済みですが、この1コミットはマージのタイミングに間に合いませんでした。

## なぜ

Fable 2026-09-09:「daily-signal の予備実行では通知ステップを必ずスキップし、JSON とログの生成のみにする。**二重通知は欠落より悪い**」

## 調べて分かったこと

**daily-signal.yml にメール送信・X投稿・realtime_notifier は存在しませんでした。** すべて別系統が独自の cron で持っています。

| 通知 | 実体 | 持ち主 | daily-signal との関係 |
|---|---|---|---|
| メール・Discord（ザラ場） | `realtime_notifier.py` | `realtime-signal.yml`（15分毎） | 無関係（別 cron） |
| メール（朝の逆指値） | `realtime_notifier.py --digest` | `morning-digest.yml`（JST 8:05） | 無関係（別 cron） |
| X投稿 | `make_x_post.py` | `ai-analysis.yml` | 無関係（別 cron） |

どれも daily-signal の完了に連動していないので、予備実行で二重に鳴ることはありません。

## 何を直したか

daily-signal で人に届くのは **Issue 作成**だけ。ここを予備の回では止めます。
guard に `is_backup` を持たせ、**Issue ステップだけ**がそれを見ます。JSON・artifact・`signals_log.csv` は予備でも作るので**データは欠けません**。

予備は本命が落ちた日にしか動かない（冪等ガードがある）ので元々二重にはならないはずですが、指示のとおり、はずれても害の無い側に倒しました。

## 確かめたこと

guard の分岐を4ケースで机上実行:

| 起動 | is_backup | Issue |
|---|---|---|
| 手動実行 | false | 作る |
| UTC 09時（夕の本命） | false | 作る |
| UTC 23時（朝の本命） | false | 作る |
| **UTC 12時（予備）** | **true** | **作らない** |

YAML として妥当なことも確認済み。差分は `daily-signal.yml` の1ファイルだけです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
