### PR TITLE
chore(scanner_free): 呼び出し元の無い2関数を削除する（§14 の後始末）

### DIFF
--- a/scanner_free.py
+++ b/scanner_free.py
@@ -353,35 +353,6 @@ def _prev_business_day_from_now():
     return d
 
 
-def _expected_target_date(delay: int):
-    """実行時点で本来 target_date になっているはずの営業日。
-
-    当日の終値が確定するのは 15:00 JST 以降。それより前に走った場合は
-    前営業日までしか使えないので、そこから delay 営業日さかのぼる。
-    **祝日は考慮していない**ため、祝日明けに1営業日ぶん多く「遅れ」と出ることがある。
-    黙って古い日付を出すよりは安全側なので、この粗さで運用する。
-    """
-    now = datetime.now(JST)
-    d = now.date()
-    if now.hour < 15 or d.weekday() >= 5:
-        d = _prev_business_day(d)
-    for _ in range(delay):
-        d = _prev_business_day(d)
-    return d
-
-
-def _business_days_between(actual, expected) -> int:
-    """actual が expected より何営業日ぶん古いか。追いついていれば 0。"""
-    lag = 0
-    d = expected
-    while d > actual:
-        d = _prev_business_day(d)
-        lag += 1
-        if lag > 60:                 # 異常値で回り続けない
-            break
-    return lag
-
-
 # ─────────────────────────────────────────────
 #  メイン
 # ─────────────────────────────────────────────


### PR DESCRIPTION
## なにをしたか

`scanner_free.py` から、**呼び出し元の無い2つの関数**を削除しました。

- `_expected_target_date()`
- `_business_days_between()`

**削除29行・追加0行。ロジックは変えていません。**

## なぜ残っていたか

- **PR #374**（§13 + §9）で `target_date_expected` / `target_date_lag_days` / `target_date_stale` を出す実装を入れ、その計算にこの2つを使っていました。
- その **32分後にマージされた PR #375** が、同じ `scanner_free.py` のその出力5行を削除し、**`asof`（その実行で使えた日経の最新終値日）と `stale`（`asof < 前営業日`）** を `free_scanner.json` / `market_jiai.json` の両方に出す方式へ置き換えました。
- 目的（実行が飛んだ・遅れたことを機械で分かるようにする）は現行方式で満たされていますが、**そこからしか呼ばれていなかったこの2関数だけが残っていました**。

## 確認したこと

- リポジトリ全体（`*.py` / `*.yml` / `*.md`）を検索し、**定義以外の参照が0件**であることを確認
- `python -m py_compile scanner_free.py` が通ること
- 差分が**削除のみ**（`git diff --numstat` = `0 29`）であること
- `_prev_business_day()` は `_prev_business_day_from_now()` から使われているので**残しています**

## 関連

- 指示書 `指示書_無料版スキャナー_サイト連携.md` §14-2 の本文は、現行仕様（`asof` / `stale`）に合わせて書き直しました（旧3キーは「PR #375 で置き換え」の1行を残置）。指示書はこのリポジトリの管理外なのでローカルのみの変更です。
- 残タスク：今夜以降で `signals_today_count >= 1` の日に `signal_of_day` が非nullであることを1回確認（§13 の受け入れ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
