### PR TITLE
⏰ cron の予定時刻を3時間前倒しする（常時2〜5時間遅れているため）

### DIFF
--- a/.github/workflows/daily-signal.yml
+++ b/.github/workflows/daily-signal.yml
@@ -9,7 +9,8 @@ on:
   schedule:
     - cron: '0 23 * * 0-4'   # 朝 08:00 JST(月〜金)
     - cron: '0 3 * * 1-5'    # 昼 12:00 JST(月〜金)
-    - cron: '0 9 * * 1-5'    # 夕 18:00 JST(月〜金)
+    # ★3時間前倒し（2026-09-09 Fable 相談⑧）。狙いは JST 18:00
+    - cron: '0 6 * * 1-5'    # 夕 18:00 JST(月〜金)
     - cron: '30 10 * * 1-5'  # 予備: 夕方の本命(18:00 JST)の90分後(JST 19:30)。夕の回が起動しなかった日の保険
   workflow_dispatch:          # 手動実行も可能
     inputs:
@@ -58,23 +59,29 @@ jobs:
           # ★このワークフローは朝(8:00)・昼(12:00)・夕(18:00)の1日3回動くのが正常。
           #   鮮度で判定してよいのは**予備の回だけ**。朝や昼の回でスキップすると
           #   本来の3回運用が壊れる（当日ぶんは朝の時点で既にあるため）。
-          #   予備は JST 19:30 = UTC 10:30 に置いてあるので、その回だけ見る。
-          HOUR_UTC=$(date -u +%H); MIN_UTC=$(date -u +%M)
+          #
+          # ★判定は「実行時刻」ではなく「どの cron で起動したか」で行う★
+          #   以前は UTC 10〜13時台を予備とみなしていたが、schedule は常時
+          #   2〜5時間遅れる（2026-09-09 に19本すべてで観測）。本命の夕を
+          #   UTC 06:00 に前倒しすると、4時間遅れれば UTC 10時台に起動し、
+          #   **本命が予備と誤判定されて朝の記録を見てスキップされる**。
+          #   github.event.schedule なら起動元の cron 式がそのまま入るので、
+          #   どれだけ遅れても取り違えない。
+          SCHEDULE='${{ github.event.schedule }}'
           if [ "${{ github.event_name }}" != "schedule" ]; then
             echo "手動実行なのでスキップ判定をしません"
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "is_backup=false" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # 予備の回（UTC 10:30 前後）以外は必ず実行する。
-          # schedule は数時間遅れることがあるので、幅を持たせて 10〜13時台を予備とみなす
-          if [ "$HOUR_UTC" -lt 10 ] || [ "$HOUR_UTC" -gt 13 ]; then
-            echo "本命の回（朝/昼/夕）なので必ず実行します（UTC ${HOUR_UTC}:${MIN_UTC}）"
+          if [ "$SCHEDULE" != "30 10 * * 1-5" ]; then
+            echo "本命の回（朝/昼/夕）なので必ず実行します（cron: $SCHEDULE）"
             echo "skip=false" >> $GITHUB_OUTPUT
             echo "is_backup=false" >> $GITHUB_OUTPUT
             exit 0
           fi
           # ここから先は予備の回。人に届くもの（Issue）は出さない。
+          echo "予備の回です（cron: $SCHEDULE）"
           echo "is_backup=true" >> $GITHUB_OUTPUT
           if python check_freshness.py --target signals_log; then
             echo "当日ぶんは取得済み。以降のステップを飛ばします"

--- a/.github/workflows/free-scanner.yml
+++ b/.github/workflows/free-scanner.yml
@@ -4,7 +4,12 @@ name: Free Scanner (無料版BNFスキャナー)
 # 無料版は1営業日遅れのデータなので、GitHubのcron遅延があっても実害なし。
 on:
   schedule:
-    - cron: '30 10 * * 1-5'
+    # ★3時間前倒し（2026-09-09 Fable 相談⑧）★
+    # GitHub Actions の schedule は**常時2〜5時間遅れる**（19本すべてで観測。
+    # 中央値 free-scanner 192分・precompute-daily 277分）。分をずらしても効かない。
+    # 狙いの JST 19:30 に走らせるため、予定は JST 16:30 に置く。
+    # 遅延が小さい日でも大引け（15:00 JST）の後なので終値は確定している。
+    - cron: '30 7 * * 1-5'
     - cron: '30 11 * * 1-5'  # 予備: 本命の60分後(JST 20:30)。本命が起動しなかった日の保険
   workflow_dispatch:
 

--- a/.github/workflows/precompute-daily.yml
+++ b/.github/workflows/precompute-daily.yml
@@ -10,7 +10,11 @@ name: Precompute Metrics (日次差分)
 # テーブルは ruletrade-app/supabase/schema.sql を SQL Editor で先に流しておくこと。
 on:
   schedule:
-    - cron: '30 9 * * 1-5'    # 夕 18:30 JST(月〜金)
+    # ★3時間前倒し（2026-09-09 Fable 相談⑧）。狙いは JST 18:30
+    #   遅延が無い日は JST 15:30 に走る。大引け直後で yfinance に当日終値が
+    #   載っていないことがあるが、その場合は前営業日までが入るだけで壊れない
+    #   （乖離検査＝§19 相談⑥ が異常値の公開を止める）。
+    - cron: '30 6 * * 1-5'    # 予定 15:30 JST / 狙い 18:30 JST(月〜金)
     - cron: '30 10 * * 1-5'  # 予備: 本命の60分後(JST 19:30)。本命が起動しなかった日の保険
   workflow_dispatch:
     inputs:

--- a/.github/workflows/radar-publish.yml
+++ b/.github/workflows/radar-publish.yml
@@ -24,7 +24,7 @@ on:
     workflows: ["Daily Trading Signal (v2.8.1)"]
     types: [completed]
   schedule:
-    - cron: '0 11 * * 1-5'   # 予備: JST 20:00（本命の公開 JST 18:20 前後の約100分後）
+    - cron: '0 8 * * 1-5'    # 予備: 予定 17:00 JST / 狙い 20:00 JST（3時間前倒し）
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
2026-09-09 Fable 相談⑧（案A）。19:30 の鮮度チップ観測に入ったところ、**その時刻に本命が起動していませんでした**。調べたら事故ではなく**常態**でした。

## 観測 — schedule で動く全19本が遅れている

直近6回の中央値です。

| 分の指定 | ワークフロー | 遅れ中央値 | 最大 |
|---|---|---|---|
| :05 | cot-weekly | 30分 | 297分 |
| :10 | ai-weekly | 104分 | 104分 |
| :03,:23 | heatmap | 116分 | 261分 |
| :05 | morning-digest | 120分 | 120分 |
| :47 | crash-daily | 174分 | 278分 |
| **:30** | **free-scanner** | **192分** | 268分 |
| :00,:30 | daily-signal | 241分 | 296分 |
| :07 | shinyo-weekly | 254分 | 609分 |
| **:30** | **precompute-daily** | **277分** | 277分 |

**「毎時0分・30分は混むので分をずらす」は効きません。** `:05` でも `:47` でも同じように遅れており、リポジトリ全体の傾向です。

## 変更（分は変えない）

予定を3時間早めて、狙いの時刻に実起動させます。

| ワークフロー | 変更 | 予定 → 狙い |
|---|---|---|
| free-scanner 本命 | UTC 10:30 → **07:30** | JST 16:30 → 19:30 |
| precompute-daily 本命 | UTC 09:30 → **06:30** | JST 15:30 → 18:30 |
| daily-signal 夕 | UTC 09:00 → **06:00** | JST 15:00 → 18:00 |
| radar-publish 予備 | UTC 11:00 → **08:00** | JST 17:00 → 20:00 |

**予備 cron・冪等ガード・morning-gate はそのまま維持**しています。

## あわせて直したもの（前倒しで壊れる箇所）

`daily-signal` のガードは「実行時刻が UTC 10〜13時台なら予備」で判定していました。本命の夕を UTC 06:00 に前倒しすると、**4時間遅れれば UTC 10時台に起動し、本命が予備と誤判定されて朝の記録を見てスキップされます**。

`github.event.schedule`（起動元の cron 式）で判定するように変えました。どれだけ遅れても取り違えません。

## 承知のうえの副作用

遅延が小さい日は `daily-signal` 夕が **JST 15:00（大引けちょうど）**、`precompute-daily` が **JST 15:30** に走ります。yfinance に当日終値が載っていなければ前営業日までが入るだけで壊れません（乖離検査＝§19 相談⑥ が異常値の公開を止め、予備の回が古さを見て取り直します）。

気になるようなら `daily-signal` 夕だけ2時間前倒し（UTC 07:00 / JST 16:00）に緩めることもできます。

## この先

本命の対策は **Cloudflare Workers の Cron Trigger から GitHub API の `workflow_dispatch` を叩く方式**（PAT は stock-trading- 限定の fine-grained・本人発行・Worker Secret）。その後 19本の schedule を順序付き1本のパイプライン＋週次1本に統合します。起動文は Fable が出します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
