### PR TITLE
⏰ Cloudflare の Cron Trigger から GitHub Actions を起こす Worker

### DIFF
--- a/cron-worker/README.md
+++ b/cron-worker/README.md
@@ -1,0 +1,117 @@
+# ruletrade-cron — GitHub Actions を時間どおりに起こす Worker
+
+## これは何のためか
+
+GitHub Actions の `schedule` は**常時2〜5時間遅れて起動する**。
+2026-09-09 に schedule で動く19本すべてを調べた結果（直近6回の中央値）:
+
+| 分の指定 | ワークフロー | 遅れ中央値 | 最大 |
+|---|---|---|---|
+| :05 | cot-weekly | 30分 | 297分 |
+| :47 | crash-daily | 174分 | 278分 |
+| :30 | free-scanner | 192分 | 268分 |
+| :00,:30 | daily-signal | 241分 | 296分 |
+| :30 | precompute-daily | 277分 | 277分 |
+
+「毎時0分・30分は混むので分をずらす」は**効かない**（`:05` でも `:47` でも同じように遅れる）。
+2026-09-05 には free-scanner が丸ごと起動せず、公開JSONの対象日が4日間止まった。
+GitHub は「起動しなかった」を失敗として記録しないので誰も気づけなかった。
+
+Cloudflare の Cron Trigger は数秒〜数十秒のずれで動く。
+ここから GitHub API の `workflow_dispatch` を叩けば、**狙った時刻に確実に走る**。
+
+## GitHub 側の schedule は消さない
+
+この Worker が落ちたときの保険として残す。
+二重に走っても各ワークフローの**冪等ガード**（当日ぶんが既にあればスキップ）が効くので害はない。
+
+---
+
+## 本人にやってもらうこと（3ステップ）
+
+### 1. GitHub の PAT を発行する
+
+https://github.com/settings/personal-access-tokens/new
+
+| 項目 | 値 |
+|---|---|
+| Token name | `ruletrade-cron-worker` |
+| Expiration | 1年（切れたら作り直す。期限なしにしない） |
+| Repository access | **Only select repositories** → `stock-trading-` **だけ** |
+| Permissions → Repository permissions → **Actions** | **Read and write** |
+
+Actions 以外は触らない（既定の Metadata: Read-only はそのまま残る）。
+
+> **このトークンはチャットに貼らないでください。** 次の手順で端末に直接入力します。
+> 漏れるとこのリポジトリのワークフローを誰でも起動できます。
+
+発行すると `github_pat_...` が1度だけ表示される。**その画面を閉じる前に次へ進む。**
+
+### 2. Cloudflare にデプロイする
+
+このフォルダ（`cron-worker/`）で実行する。
+
+```bash
+npx wrangler login
+```
+
+ブラウザが開くので Cloudflare にログインして許可する。続けて:
+
+```bash
+npx wrangler deploy
+```
+
+### 3. トークンを Worker に渡す
+
+```bash
+npx wrangler secret put GH_PAT
+```
+
+`Enter a secret value:` と出たら、**1で発行した `github_pat_...` を貼って Enter**。
+画面には表示されない。これで Cloudflare 側に暗号化して保存される。
+
+---
+
+## 動いているか確かめる
+
+デプロイ時に表示された URL（`https://ruletrade-cron.<アカウント名>.workers.dev`）を開くと、
+今の JST と設定内容が JSON で返る。**開くだけでは何も起動しない。**
+
+```json
+{
+  "now_jst": "2026-09-10 08:00",
+  "weekday": true,
+  "has_token": true,      ← false ならステップ3ができていない
+  "repo": "oo12takemaru-create/stock-trading-",
+  "plan": { "08:00": ["daily-signal.yml"], ... }
+}
+```
+
+実際の起動ログは Cloudflare のダッシュボード → Workers & Pages → ruletrade-cron → Logs で見る。
+
+翌営業日の朝、GitHub の Actions 一覧で **`workflow_dispatch` 起動のものが予定時刻ちょうどに並んでいれば成功**。
+
+---
+
+## 起動する時刻（JST・平日のみ）
+
+| 時刻 | ワークフロー | |
+|---|---|---|
+| 08:00 | daily-signal | 朝 |
+| 12:00 | daily-signal | 昼 |
+| 18:00 | daily-signal | 夕（終値ベース。radar-publish がこの完了で連鎖する） |
+| 18:30 | precompute-daily | 前計算 → 公開数字 → score3_lite → キャッシュ温め |
+| 19:30 | free-scanner | 無料版スキャナー |
+| 20:30 | free-scanner | 予備 |
+| 22:30 | precompute-daily | 予備 |
+
+時刻を足す・変えるときは `src/index.js` の `PLAN` を直して `npx wrangler deploy` するだけ。
+`wrangler.toml` の Cron Trigger（毎時0分・30分）は触らない。
+
+> Cron Trigger を1本にしてあるのは、無料プランが1 Worker あたり3本までのため。
+> 毎時起こして Worker の中で JST を見て振り分けている。
+
+## 費用
+
+無料枠の範囲。1日48回起動 × 平日のみで月1,000回程度、
+無料枠は10万リクエスト/日なので桁がいくつも違う。

--- a/cron-worker/package.json
+++ b/cron-worker/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "ruletrade-cron",
+  "private": true,
+  "description": "GitHub Actions の schedule 遅延（常時2〜5時間）を避けるため、Cloudflare の Cron Trigger から workflow_dispatch を叩く",
+  "scripts": {
+    "deploy": "wrangler deploy",
+    "dev": "wrangler dev",
+    "tail": "wrangler tail"
+  },
+  "devDependencies": {
+    "wrangler": "^3.90.0"
+  }
+}

--- a/cron-worker/src/index.js
+++ b/cron-worker/src/index.js
@@ -1,0 +1,128 @@
+/**
+ * GitHub Actions の schedule を Cloudflare の Cron Trigger で置き換える。
+ *
+ * ■ なぜ要るか（引継ぎ.md §19-8 / 2026-09-09 Fable 相談⑧）
+ * GitHub Actions の schedule は**常時2〜5時間遅れて起動する**。
+ * 19本すべてで観測し、中央値は free-scanner 192分・precompute-daily 277分・
+ * daily-signal 241分。「毎時0分・30分は混むので分をずらす」は効かない
+ * （:05 でも :47 でも同じように遅れた）。
+ * 2026-09-05 には free-scanner が丸ごと起動せず、公開JSONの対象日が
+ * 4日間止まった。GitHub は「起動しなかった」を失敗として記録しないので
+ * 誰も気づけなかった。
+ *
+ * Cloudflare の Cron Trigger は数秒〜数十秒のずれで動く。ここから
+ * GitHub API の workflow_dispatch を叩けば、狙った時刻に確実に走る。
+ *
+ * ■ GitHub 側の schedule は消さない
+ * この Worker が落ちたときの保険として残す。二重に走っても、各ワークフローの
+ * 冪等ガード（当日ぶんが既にあればスキップ）が効くので害はない。
+ *
+ * ■ Cron Trigger は1本だけにしてある
+ * 無料プランは1 Worker あたり3本まで。時刻ごとに分けると足りないので、
+ * 「毎時 0分・30分」に起こして、Worker の中で JST を見て振り分ける。
+ * 時刻を足したいときは下の PLAN に1行足すだけでよい（wrangler.toml は触らない）。
+ */
+
+const REPO = "oo12takemaru-create/stock-trading-";
+const REF = "main"; // workflow_dispatch は既定ブランチのものしか動かない
+
+/**
+ * JST の "HH:MM" → その時刻に起こすワークフロー（配列の順に叩く）。
+ *
+ * ★ここに書くのは「実際に走ってほしい時刻」★
+ * GitHub の schedule 側は遅延を見越して3時間前倒ししてあるが（PR #380）、
+ * こちらは遅れないので前倒し不要。素直に狙いの時刻を書く。
+ */
+const PLAN = {
+  "08:00": ["daily-signal.yml"],       // 朝
+  "12:00": ["daily-signal.yml"],       // 昼
+  "18:00": ["daily-signal.yml"],       // 夕（終値ベース・radar-publish がこの完了で連鎖する）
+  "18:30": ["precompute-daily.yml"],   // 前計算 → 公開数字 → score3_lite → キャッシュ温め
+  "19:30": ["free-scanner.yml"],       // 無料版スキャナー
+  "20:30": ["free-scanner.yml"],       // 予備（当日ぶんがあれば冪等ガードで何もしない）
+  "22:30": ["precompute-daily.yml"],   // 予備
+};
+
+/** 平日だけ動かす（土日は日本市場が休み） */
+function isWeekday(jst) {
+  const d = jst.getUTCDay(); // jst は「JSTの壁時計をUTCとして持つ」Date
+  return d >= 1 && d <= 5;
+}
+
+/** now(UTC) を JST の壁時計に直す */
+function toJst(now) {
+  return new Date(now.getTime() + 9 * 60 * 60 * 1000);
+}
+
+function hhmm(jst) {
+  const h = String(jst.getUTCHours()).padStart(2, "0");
+  const m = String(jst.getUTCMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+async function dispatch(workflow, env) {
+  const url = `https://api.github.com/repos/${REPO}/actions/workflows/${workflow}/dispatches`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      // User-Agent が無いと GitHub API は 403 を返す
+      "User-Agent": "ruletrade-cron-worker",
+      "Accept": "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "Authorization": `Bearer ${env.GH_PAT}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ref: REF }),
+  });
+  // 成功は 204。本文は空
+  const ok = res.status === 204;
+  const detail = ok ? "" : ` ${res.status} ${(await res.text()).slice(0, 200)}`;
+  console.log(`${ok ? "OK  " : "NG  "} ${workflow}${detail}`);
+  return ok;
+}
+
+export default {
+  async scheduled(event, env, ctx) {
+    const jst = toJst(new Date(event.scheduledTime));
+    const key = hhmm(jst);
+    const targets = PLAN[key];
+
+    if (!targets) {
+      console.log(`JST ${key}: 予定なし`);
+      return;
+    }
+    if (!isWeekday(jst)) {
+      console.log(`JST ${key}: 土日なので何もしない`);
+      return;
+    }
+    if (!env.GH_PAT) {
+      // 黙って何もしないと「動いているつもり」になる。必ず記録に残す
+      console.error("GH_PAT が設定されていません。何も起動できません");
+      return;
+    }
+
+    console.log(`JST ${key}: ${targets.length} 本を起動します`);
+    for (const wf of targets) {
+      // 順に叩く（並列にしない＝順序を保つ）
+      await dispatch(wf, env);
+    }
+  },
+
+  /**
+   * 動作確認用。ブラウザで開くと今の JST と、次に何が起きるかを返す。
+   * 起動はしない（GET で副作用を起こさない）。
+   */
+  async fetch(request, env) {
+    const jst = toJst(new Date());
+    const body = {
+      now_jst: jst.toISOString().replace("T", " ").slice(0, 16),
+      weekday: isWeekday(jst),
+      has_token: Boolean(env.GH_PAT),
+      repo: REPO,
+      plan: PLAN,
+    };
+    return new Response(JSON.stringify(body, null, 2), {
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+    });
+  },
+};

--- a/cron-worker/wrangler.toml
+++ b/cron-worker/wrangler.toml
@@ -1,0 +1,16 @@
+name = "ruletrade-cron"
+main = "src/index.js"
+compatibility_date = "2026-09-09"
+
+# ★Cron Trigger は1本だけ★
+#   無料プランは1 Worker あたり3本まで。時刻ごとに分けると足りないので、
+#   毎時 0分・30分に起こして、Worker の中で JST を見て振り分ける。
+#   起動時刻を足したいときは src/index.js の PLAN に1行足すだけでよく、
+#   ここは触らない。
+#
+#   Cloudflare の cron は UTC だが、この書き方なら時差の計算が要らない。
+[triggers]
+crons = ["0,30 * * * *"]
+
+# 秘密は wrangler secret put で入れる（このファイルには書かない）
+#   npx wrangler secret put GH_PAT


### PR DESCRIPTION
2026-09-09 Fable 相談⑧ の**本命**。案A（3時間前倒し・[#380](https://github.com/oo12takemaru-create/stock-trading-/pull/380)）は応急処置で、遅れ幅が 178〜582分とばらつくため確実ではありません。

## 背景

GitHub Actions の `schedule` は**常時2〜5時間遅れます**。19本すべてで観測した中央値です。

| 分の指定 | ワークフロー | 遅れ中央値 |
|---|---|---|
| :05 | cot-weekly | 30分 |
| :47 | crash-daily | 174分 |
| :30 | free-scanner | 192分 |
| :00,:30 | daily-signal | 241分 |
| :30 | precompute-daily | 277分 |

「毎時0分・30分は混むので分をずらす」は**効きません**。2026-09-05 には free-scanner が丸ごと起動せず、公開JSONが4日間止まりました。GitHub は「起動しなかった」を失敗として記録しないので気づけません。

Cloudflare の Cron Trigger は数秒〜数十秒のずれで動きます。そこから GitHub API の `workflow_dispatch` を叩けば**狙った時刻に確実に走ります**。

## 中身

| ファイル | 役割 |
|---|---|
| `cron-worker/src/index.js` | 時刻の振り分けと `workflow_dispatch` |
| `cron-worker/wrangler.toml` | Cron Trigger は**1本**（毎時0分・30分） |
| `cron-worker/README.md` | 本人向けの手順（3ステップ） |

Cron Trigger を1本にしたのは**無料プランが1 Worker あたり3本まで**のためです。毎時起こして Worker の中で JST を見て `PLAN` で振り分けます。時刻の追加は `PLAN` に1行足すだけで、`wrangler.toml` は触りません。

## 起動する時刻（JST・平日のみ）

| 時刻 | ワークフロー | |
|---|---|---|
| 08:00 / 12:00 / 18:00 | daily-signal | 朝・昼・夕 |
| 18:30 | precompute-daily | 前計算 → 公開数字 → score3_lite → 温め |
| 19:30 | free-scanner | |
| 20:30 | free-scanner | 予備 |
| 22:30 | precompute-daily | 予備 |

**GitHub 側の schedule は消しません。** Worker が落ちたときの保険です。二重に走っても各ワークフローの冪等ガードが効くので害はありません。

## 確かめたこと

- 時刻の振り分けを**24時間×2曜日で机上実行**。水曜は7回すべて予定どおり、土曜は0回（日本市場が休みなので正しい）
- GET でアクセスすると設定と `has_token` を返すだけで、**起動はしません**（GET で副作用を起こさない）
- 全24本のワークフローが `workflow_dispatch` を持っていることを確認済み。既定ブランチは `main`

## 本人作業（README.md に手順あり）

1. **fine-grained PAT の発行** — `stock-trading-` 限定・**Actions のみ Read and write**・期限1年
2. `npx wrangler login` → `npx wrangler deploy`
3. `npx wrangler secret put GH_PAT`

> **トークンはチャットに貼らず、端末に直接入力してください。** 漏れるとこのリポジトリのワークフローを誰でも起動できます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
