### PR TITLE
📅 ポートフォリオ結果に日別の発生件数を足す

### DIFF
--- a/precompute/portfolio_run.py
+++ b/precompute/portfolio_run.py
@@ -79,6 +79,15 @@ def run(panel: pd.DataFrame, market: pd.DataFrame,
     for t in final:
         yearly.setdefault(t.exit_date.year, []).append(t)
 
+    # 日別の発生件数（公開成績ページ /p/preset の「発生カレンダー」用）。
+    # 数え方は **建てた日**（entry_date）。exit_date で数えると「いつ出たか」ではなく
+    # 「いつ終わったか」のカレンダーになり、意味が変わる。
+    # 制約を通ったあと（final）で数えるので、画面の件数と成績の母集団が一致する。
+    daily_entries = {}
+    for t in final:
+        k = t.entry_date.strftime("%Y-%m-%d")
+        daily_entries[k] = daily_entries.get(k, 0) + 1
+
     result = {
         "summary": pe.calc_stats(final),
         "unconstrained_signals": len(all_trades),
@@ -90,6 +99,9 @@ def run(panel: pd.DataFrame, market: pd.DataFrame,
             {"year": y, **pe.calc_stats(v)} for y, v in sorted(yearly.items())
         ],
         "exit_reasons": pe.exit_reason_counts(final),
+        # {"2016-09-12": 3, ...}。**該当が1件も無い日は入れない**（0を並べない）。
+        # 10年で約2,400キー・数十KB。jsonb にそのまま入る大きさ
+        "daily_entries": dict(sorted(daily_entries.items())),
         "period": {"from": start, "to": end},
         "basis": {
             "universe": "daily_scanner_v2_8_0.py の STOCKS（%d銘柄。データが揃うぶんで計算）"


### PR DESCRIPTION
公開成績ページ `/p/preset`（会員アプリ・Phase 2-④ Step 5）の「発生カレンダー」に出す材料です。

## なぜ

日別のシグナル件数を持つ表が Supabase に無く、`portfolio_results` は年別までしか持っていませんでした（DB の11表を確認）。カレンダーの材料だけが取れず、画面には「次回の集計から表示します」と出しています。

## 変えたところ

`precompute/portfolio_run.py` の結果に `daily_entries` を1キー追加するだけです。

- 数えるのは **建てた日**（`entry_date`）。決済日で数えると「いつ出たか」ではなく「いつ終わったか」のカレンダーになります
- 制約（同時保有10・同セクター3・サーキットブレーカー）を通したあとの `final` で数えるので、画面の件数と成績の母集団が一致します
- 該当が0件の日はキーごと入れません（10年で約2,400キー・数十KB。`jsonb` にそのまま入る大きさ）

## 影響

**既存の数字は変わりません。** `summary` / `yearly` / `by_rule` / `exit_reasons` はすべてそのままで、集計を1つ増やしただけです。

`build_portfolio.py` は `precompute-daily.yml` の中で毎日走るので、次の日次バッチで `portfolio_results` に入り、会員アプリ側は自動的に表示に切り替わります。会員アプリ側の対応は実装済みで、データが無い間はカレンダーを描かず理由を書くようにしてあります。

`.github/workflows/` は触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)