### PR TITLE
🔧 pipeline-daily を直列にする（同時 push で main の ref を取り合っていた）

### DIFF
--- a/.github/workflows/pipeline-daily.yml
+++ b/.github/workflows/pipeline-daily.yml
@@ -54,37 +54,49 @@ jobs:
   # 3. 地合いの公開（MCP get_market_regime・株レーダーが読む）
   #    従来は daily-signal の workflow_run で連鎖していた。パイプラインでは
   #    needs で順序が保証されるので、そちらに寄せる。
+  #    ※ free-scanner の後ろに置くのは順序の都合ではなく、**同時 push を避けるため**。
+  #      この2本も docs/*.json を main に push する（下の「並列にしてはいけない」参照）。
   radar-publish:
-    needs: daily-signal
+    needs: free-scanner
     uses: ./.github/workflows/radar-publish.yml
     secrets: inherit
 
-  # 4. 派生データ。互いに独立なので並列でよい（上流の成功は共通の前提）
+  # 4. 派生データ。**並列にしてはいけない**（2026-09-09 の実測で判明）
+  #
+  #    5本とも docs/*.json を main に push する。並列にすると rebase の直後・
+  #    push の直前に別のジョブが割り込み、
+  #      ! [remote rejected] main -> main (cannot lock ref 'refs/heads/main')
+  #    で落ちる。実際 crash と kessan-react が同時に落ちた。
+  #    どれか1本でも落ちると precompute が skipped になり、**公開数字が更新されない**。
+  #
+  #    従来は schedule で時間がばらけていたので起きなかった。1本にまとめた副作用。
+  #    互いにデータの依存は無いので、順番はどれでもよい。速さより確実さを取る。
+  #    （各ワークフローの commit ステップは触らない＝単体実行の動きを変えない）
   gauge:
-    needs: [free-scanner, radar-publish]
+    needs: radar-publish
     uses: ./.github/workflows/gauge-daily.yml
     secrets: inherit
   crash:
-    needs: [free-scanner, radar-publish]
+    needs: gauge
     uses: ./.github/workflows/crash-daily.yml
     secrets: inherit
   kessan:
-    needs: [free-scanner, radar-publish]
+    needs: crash
     uses: ./.github/workflows/kessan-daily.yml
     secrets: inherit
   kessan-react:
-    needs: [free-scanner, radar-publish]
+    needs: kessan
     uses: ./.github/workflows/kessan-react-daily.yml
     secrets: inherit
   karauri:
-    needs: [free-scanner, radar-publish]
+    needs: kessan-react
     uses: ./.github/workflows/karauri-daily.yml
     secrets: inherit
 
   # 5. 前計算 → 公開数字 → キャッシュ温め
   #    ここは daily_metrics を触るので、派生データの後ろに置いて負荷を分ける
   precompute:
-    needs: [gauge, crash, kessan, kessan-react, karauri]
+    needs: karauri  # 直列なので、最後まで来ていれば手前は全部成功している
     uses: ./.github/workflows/precompute-daily.yml
     secrets: inherit
 


### PR DESCRIPTION
2026-09-09 22:45 の実走（[run 34361166695](https://github.com/oo12takemaru-create/stock-trading-/actions/runs/34361166695)）で
`crash` と `kessan-react` が **Commit ステップ**で落ちた。

```
! [remote rejected] main -> main
  (cannot lock ref 'refs/heads/main': is at 997a91a but expected 833073e)
```

rebase までは成功し、**push の直前に別のジョブが割り込んでいる**。
派生データ5本を並列にしたので、5本が同時に `docs/*.json` を main へ push していた。

従来は `schedule` で時間がばらけていたため起きなかった。**1本にまとめた副作用**で、
並走の初日に出た。

## なぜ直さないといけないか

どれか1本でも落ちると `precompute` が `skipped` になり、**公開数字が更新されない**。
実際この回は `portfolio_stats` が 9/9 に更新されなかった。
明日 18:00 も同じところで落ちる。

## 直し方

派生データ5本を直列にした。`free-scanner` と `radar-publish` も同じ理由で直列にした
（この回はたまたま通っただけで、同じ危険がある）。

```
daily-signal → free-scanner → radar-publish → gauge → crash
  → kessan → kessan-react → karauri → precompute → healthcheck
```

互いにデータの依存は無いので順番はどれでもよい。**速さより確実さを取る。**
各ワークフローの commit ステップには触れていない（単体実行の動きは変えない）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
