### PR TITLE
💸 warm_cache を CI から外す（Supabase egress 5GB 超過の主犯）

### DIFF
--- a/.github/workflows/precompute-daily.yml
+++ b/.github/workflows/precompute-daily.yml
@@ -168,16 +168,30 @@ jobs:
           set -o pipefail
           python precompute/score3_hist.py --years 2 --days 5             --out score3_lite_recent.csv --upsert | tee -a update.log
 
-      # 調整域のキャッシュ温め（最後に回す。ここが落ちても公開数字は出ている）
-      # スライダーの体感を良くするためのもので、正しさには関わらない。
-      - name: Warm preset adjustment cache
-        if: steps.guard.outputs.skip != 'true'
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          set -o pipefail
-          python precompute/warm_cache.py | tee -a update.log
+      # ── 調整域のキャッシュ温めは **止めてある**（2026-09-10・§23 相談⑪ 案A）──
+      #
+      # なぜ止めたか: Supabase の egress 5GB/月（無料枠）を単独で超えていた。
+      #   backtest_trades() は約定明細を返す設計で、実測 1回 487KB（3,011トレード）。
+      #   warm_cache は 1,260通り叩くので **1実行で 185〜600MB**、月20営業日で 3.6〜11.7GB。
+      #   会員ゼロの段階で数GB を使っていた正体がこれ。
+      #
+      # 止めて何が起きるか: /rules のスライダーを規定値から動かしたとき、
+      #   キャッシュに当たらず毎回ライブ計算（10〜20秒）になる。**正しさには影響しない。**
+      #   画面は「計算中」を出して前の数字を薄く残す作りなので、壊れはしない。
+      #
+      # いつ戻すか: 統計だけを返す backtest_stats() を SQL に足し（§23 相談⑪ 案B・9/20 まで）、
+      #   TS の集計と 1,260通りで一致を確認してから warm_cache を切り替えて戻す。
+      #   明細を返す backtest_trades() は画面が使うので残すが、**CI からは呼ばない**。
+      #
+      # 戻すときはこのブロックのコメントを外すだけでよい。
+      # - name: Warm preset adjustment cache
+      #   if: steps.guard.outputs.skip != 'true'
+      #   env:
+      #     SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      #     SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      #   run: |
+      #     set -o pipefail
+      #     python precompute/warm_cache.py | tee -a update.log
 
       - name: Write summary
         if: always()

--- a/.github/workflows/precompute-monthly.yml
+++ b/.github/workflows/precompute-monthly.yml
@@ -103,15 +103,17 @@ jobs:
           echo "::error::3回試行してもpushできませんでした"
           exit 1
 
-      # 調整域のキャッシュ温め（最後に回す。ここが落ちても公開数字は出ている）
-      # 月次の全期間再計算のあとにキャッシュを作り直す（起動文 §1-1 の順序）。
-      - name: Warm preset adjustment cache
-        env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-        run: |
-          set -o pipefail
-          python precompute/warm_cache.py | tee -a build.log
+      # ── 調整域のキャッシュ温めは **止めてある**（2026-09-10・§23 相談⑪ 案A）──
+      # 日次（precompute-daily.yml）と同じ理由。あちらだけ止めても、月初にここで
+      # 185〜600MB を使ってしまい対策が中途半端になるので揃えて止める。
+      # 戻すときは日次と一緒に、両方のコメントを外す。
+      # - name: Warm preset adjustment cache
+      #   env:
+      #     SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      #     SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      #   run: |
+      #     set -o pipefail
+      #     python precompute/warm_cache.py | tee -a build.log
 
       - name: Write summary
         if: always()


### PR DESCRIPTION
Supabase の Fair Use 警告（無料枠 egress **5GB/月**・猶予 2026-10-10）の対策です。引継ぎ.md §23 相談⑪ の Fable 決定「**案A を今すぐ**」。

## 実測して主犯を特定しました

`backtest_trades()` は約定明細を jsonb 配列で返す設計です。実測すると：

```
dev_25<=-15 / vol_ratio_20>=1.5 / hold=5 / 全期間
  → 応答 499,006 バイト（487 KB）・3,011 トレード・6.1秒
```

`warm_cache.py` はこれを **MA 2 × 閾値 21 × 出来高 3 × 地合い 2 × 保有日数 5 = 1,260 通り**叩き、`precompute-daily.yml` で**毎日**走ります。

| 1回あたり平均 | 1実行 | 月20営業日 |
|---|---|---|
| 150 KB | 185 MB | **3.6 GB** |
| 250 KB | 308 MB | **6.0 GB** |
| 487 KB（実測値） | 599 MB | 11.7 GB |

**単独で無料枠を超えます。** 会員ゼロなのに数GB 出ていた正体がこれでした。

## 変更点

`precompute-daily.yml` と `precompute-monthly.yml` の warm_cache ステップをコメントアウトしました。**月次も揃えて止めています** — 日次だけ止めても月初に 185〜600MB 使ってしまい、対策が中途半端になるためです。

## 影響

`/rules` のスライダーを規定値から動かすと、キャッシュに当たらず毎回ライブ計算（10〜20秒）になります。**正しさには影響しません**。画面は「計算中」を出して前の数字を薄く残す作りなので壊れません。会員ゼロの今は実害なしと判断しています。

## 戻し方

統計だけを返す `backtest_stats()` を SQL に足し（案B・9/20 まで）、TS の集計と 1,260 通りで一致を確認してから warm_cache を切り替えて戻します。明細を返す `backtest_trades()` は画面が使うので残しますが、**CI からは呼びません**。戻すときは両ファイルのコメントを外すだけです。

Python コードは変更していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)