### PR TITLE
🐛 score3_lite の日次投入が必ず落ちていたのを直す

### DIFF
--- a/cron-worker/test/observe.mjs
+++ b/cron-worker/test/observe.mjs
@@ -12,12 +12,22 @@
  *   無い … 当日その時刻の run が見つからない（★これが致命的。schedule と違い黙って消える）
  *   済   … alreadyRanToday で正しく飛ばした（当日すでに success がある）
  *
+ * ■ ★workflow_dispatch = Worker とは限らない★
+ * GitHub の run には「誰が dispatch したか」がトークン単位では残らない。
+ * 2026-09-09 に、この取り違えで**誤った合格報告**を出した:
+ *   realtime-signal の workflow_dispatch を32本数えて「Worker の起動精度は
+ *   中央値24秒」と報告したが、同じ32本は Worker 配備前の 8/31 から毎日出ていた。
+ *   実際には PAT が権限ゼロで、Worker からの dispatch は1本も通っていなかった。
+ * そこで下の「配備前との比較」を必ず出す。配備前から同じ数が出ているものは
+ * **Worker の実績として数えない**。
+ *
  * 会員向けの朝の通知（7:30・HTTP）は GitHub に痕跡が残らないのでここでは見えない。
  * Cloudflare のログか、届いたメールで確かめる。
  *
  *   node cron-worker/test/observe.mjs              # 今日（JST）
  *   node cron-worker/test/observe.mjs 2026-09-10
  *   node cron-worker/test/observe.mjs 2026-09-09 from=22:00   # デプロイ後だけ見る
+ *   node cron-worker/test/observe.mjs 2026-09-10 before=2026-09-08  # 配備前と比べる
  */
 import { execFileSync } from "node:child_process";
 import { targetsFor, NO_DEDUP } from "../src/index.js";
@@ -33,6 +43,11 @@ const day = process.argv[2] || today();
 // 「無い」が並ぶだけで、本当に見たいものが埋もれる。
 const fromArg = process.argv.find((a) => a.startsWith("from="));
 const FROM = fromArg ? fromArg.slice(5) : "00:00";
+
+// Worker 配備より前の営業日。ここでも同じ dispatch が出ているなら、
+// それは Worker の仕業ではない（2026-09-09 に取り違えた）。
+const beforeArg = process.argv.find((a) => a.startsWith("before="));
+const BEFORE = beforeArg ? beforeArg.slice(7) : null;
 
 // ── 予定を作る（本番と同じ targetsFor を使う）──
 const expected = []; // { at: "HH:MM", workflow }
@@ -52,7 +67,8 @@ const byId = new Map(
 );
 
 const raw = execFileSync("gh", [
-  "run", "list", "--limit", "250",
+  // before= のときは配備前の日まで遡る必要があるので多めに取る
+  "run", "list", "--limit", BEFORE ? "900" : "250",
   "--json", "name,event,createdAt,conclusion,status,workflowDatabaseId",
 ], { encoding: "utf8", maxBuffer: 32 * 1024 * 1024 });
 
@@ -129,4 +145,33 @@ if (missing > 0) {
       "\n  起動しなかったことは GitHub に失敗として残らない（2026-09-05 の4日間放置と同じ形）。",
   );
 }
-console.log("\n※ 会員向けの朝の通知（7:30・HTTP）はここには出ない。Cloudflare のログかメールで確認する。");
+if (BEFORE) {
+  const past = JSON.parse(raw)
+    .map((r) => ({
+      file: byId.get(r.workflowDatabaseId) || "",
+      event: r.event,
+      jst: new Date(Date.parse(r.createdAt) + 9 * 3600 * 1000),
+    }))
+    .filter((r) => r.jst.toISOString().slice(0, 10) === BEFORE && r.event === "workflow_dispatch");
+
+  const cnt = (rows) => rows.reduce((m, r) => (m[r.file] = (m[r.file] || 0) + 1, m), {});
+  const now = cnt(runs.filter((r) => r.event === "workflow_dispatch"));
+  const old = cnt(past);
+
+  console.log(`\n=== 配備前（${BEFORE}）との比較: workflow_dispatch の本数 ===`);
+  if (past.length === 0) {
+    console.log(`  ${BEFORE} の run が取得範囲に入っていない（--limit を増やすか日付を変える）`);
+  } else {
+    for (const f of new Set([...Object.keys(now), ...Object.keys(old)])) {
+      const a = old[f] || 0, b = now[f] || 0;
+      const note = a > 0 && b <= a
+        ? "★配備前から同数以上ある＝Worker の実績として数えない"
+        : a > 0 ? "配備前にもある（増えた分だけが Worker の可能性）" : "配備後だけ";
+      console.log(`  ${f.padEnd(26)} 配備前 ${String(a).padStart(3)} → 当日 ${String(b).padStart(3)}   ${note}`);
+    }
+  }
+}
+
+console.log("\n※ workflow_dispatch は「誰が叩いたか」を区別できない。Worker の実績を主張する前に");
+console.log("   上の比較か Cloudflare のログ（npx wrangler tail）で必ず裏を取る。");
+console.log("※ 会員向けの朝の通知（7:30・HTTP）はここには出ない。Cloudflare のログかメールで確認する。");

--- a/precompute/score3_hist.py
+++ b/precompute/score3_hist.py
@@ -518,10 +518,48 @@ def main():
 
     if args.upsert:
         import supabase_io
-        cols = ["date", "score3_lite", "score3_axis1", "score3_axis2",
-                "score3_axis3", "score3_label"]
-        recs = supabase_io.frame_to_records(df[cols])
-        supabase_io.upsert("market_condition", recs, on_conflict="date")
+
+        # ★score3 の列だけを送ってはいけない★
+        # `supabase_io.upsert` は PostgREST の upsert で、**行全体を置き換える**。
+        # 送らなかった列は既定値（= null）で埋まるので、`regime` のような
+        # NOT NULL 列が null になり 400（23502）で落ちる。
+        #   実際に 2026-09-10 の日次バッチが、まさにこれで落ちた:
+        #   null value in column "regime" of relation "market_condition"
+        # 引継ぎ.md §20-3 に「既存行を読んでマージして書き戻す」と書きながら、
+        # このコードパスに入れ忘れていた（10年ぶんの初回投入は手作業でマージしていた）。
+        #
+        # 対処: 対象日の既存行を丸ごと読み、score3 列だけ差し替えて、
+        #       **完全な行として**書き戻す。読み書き1往復ずつで済む。
+        score_cols = ["score3_lite", "score3_axis1", "score3_axis2",
+                      "score3_axis3", "score3_label"]
+        recs = supabase_io.frame_to_records(df[["date"] + score_cols])
+        by_date = {r["date"]: r for r in recs}
+        days_sorted = sorted(by_date)
+
+        existing = supabase_io.select_rows(
+            "market_condition", "*",
+            "date=gte.%s&date=lte.%s" % (days_sorted[0], days_sorted[-1]))
+
+        merged = []
+        for row in existing:
+            d = row.get("date")
+            if d not in by_date:
+                continue                      # 計算対象外の日はそのまま
+            for c in score_cols:
+                row[c] = by_date[d][c]
+            merged.append(row)
+
+        # market_condition に行が無い日は**入れない**。
+        # score3 だけの行を作ると regime が null になって同じ 400 を踏む。
+        # その日はスキャナー側がまだ書いていないだけなので、翌回に入る。
+        missing = sorted(set(by_date) - {r.get("date") for r in existing})
+        if missing:
+            print("market_condition にまだ無い日は飛ばします: %s" % ", ".join(missing))
+
+        if merged:
+            supabase_io.upsert("market_condition", merged, on_conflict="date")
+        else:
+            print("投入対象がありません（market_condition に該当日が1つもない）")
     return 0
 
 

--- a/precompute/supabase_io.py
+++ b/precompute/supabase_io.py
@@ -223,6 +223,30 @@ def count_rows(table, query=""):
     return int(cr.split("/")[-1]) if "/" in cr else 0
 
 
+def select_rows(table, columns="*", query="", page=1000):
+    """行を読む。**1000行ずつページングする。**
+
+    ★PostgREST は返却行数の上限（既定1000）を超えたぶんを、エラーも出さずに捨てる。★
+    「全部取ったつもりで一部しか無い」という壊れ方をするので、必ずここを通すこと
+    （引継ぎ.md §19-2）。
+
+    query は "date=gte.2026-09-01&date=lte.2026-09-10" のような PostgREST の条件。
+    """
+    url_base, key = credentials()
+    out = []
+    offset = 0
+    while True:
+        endpoint = "%s/rest/v1/%s?select=%s%s&limit=%d&offset=%d" % (
+            url_base, table, columns,
+            ("&" + query if query else ""), page, offset)
+        status, body = _request("GET", endpoint, key)
+        rows = json.loads(body.decode("utf-8"))
+        out.extend(rows)
+        if len(rows) < page:
+            return out
+        offset += page
+
+
 def max_value(table, column):
     """table の column の最大値（最新日付の確認用）。"""
     url_base, key = credentials()


### PR DESCRIPTION
2026-09-10 の Pipeline Daily（21:00・Worker からの初 dispatch）が `precompute / update` の **「Update score3_lite」で failure** しました。実行のたびに落ちていたはずです。

## 何が起きていたか

```
supabase_io.SupabaseError: 投入に失敗 (HTTP 400)
{"code":"23502","details":"Failing row contains (2026-09-04, null, null, ..., -2, -1, -1, 0, やや守り).",
 "message":"null value in column \"regime\" of relation \"market_condition\" violates not-null constraint"}
```

score3 の列だけを upsert していました。`supabase_io.upsert` は PostgREST の upsert で **行全体を置き換える**ため、送らなかった列（`regime`・`nikkei_close` など）が null で埋まり、NOT NULL 制約に当たっていました。

引継ぎ.md §20-3 に「**既存行を読んでマージし、完全な行として書き戻すこと**」と書いておきながら、`--upsert` のコードパスに入れ忘れていました。10年ぶんの初回投入は手作業でマージしたので通っており、**日次バッチだけが毎回落ちていた**という形です。

## 直し方

対象日の既存行を丸ごと読み、score3 の5列だけ差し替えて、**完全な行として**書き戻します（読み書き1往復ずつ）。`market_condition` にまだ行が無い日は**入れません** — score3 だけの行を作ると同じ 400 を踏むためで、その日はスキャナー側が書いた翌回に入ります。

あわせて `supabase_io` に `select_rows()` を足しました。**1000行ずつページングします**（PostgREST は上限超過を黙って捨てるため・§19-2）。

## 検証（本番 DB で実行）

```
python precompute/score3_hist.py --years 2 --days 5 --upsert
  → market_condition: 5 / 5 行 (0秒)   … 成功
```

投入後の確認：

| 日 | regime | nikkei_close | score3_lite |
|---|---|---|---|
| 2026-08-31 | BULLISH | 66311.93 | +1 |
| 2026-09-01 | BULLISH | 66215.34 | 0 |
| 2026-09-02 | BULLISH | 64325.64 | −3 |
| 2026-09-03 | BULLISH | 64214.48 | −2 |
| 2026-09-04 | BULLISH | 65020.94 | −2 |

**regime が null の行: 0 / score3_lite が入っている行: 2,438**（変わらず）。既存の値を壊していません。

`.github/workflows/` は触っていません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)